### PR TITLE
Clean up Vore features port

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -96,67 +96,98 @@
 //This should most likely be preattack. Check whenever possible (doing a straight port)
 /obj/item/weapon/holder/micro/afterattack(var/mob/living/carbon/target, var/mob/user, var/proximity)
 	if(!proximity) return
-	for(var/mob/living/M in src.contents)
-		if(istype(target,/mob/living/carbon/human) || istype(target,/mob/living/carbon/alien || istype(target,/mob/living/simple_animal)))
+	for(var/mob/living/M in contents)
+		if(ishuman(target) || isalien(target) || isanimal(target))
+
 			if(M == target)
 				return
+
+		//Oral Vore
 			if(target.vorifice == "Oral Vore")
 				user.visible_message("<span class='danger'>[user] is attempting to stuff [M] down [target]'s throat!</span>")
+
 				if(!do_mob(user, M)||!do_after(user, 100)) return
+
 				user.visible_message("<span class='danger'>[target] swallows the last of [M]!</span>")
+
 				M.loc = target
-				src.contents.Remove(M)
+				//contents.Remove(M) //This isn't neccessary. contents is handled by BYOND and hooked into loc, they will be removed by setting the loc.
 				target.stomach_contents.Add(M)
+
 				if(target == user)
 					msg_admin_attack("[key_name(user)] oral vored [key_name(M)]")
 				else
 					msg_admin_attack("[key_name(user)] fed [key_name(M)] to [key_name(target)]")
+
 				playsound(src, 'sound/vore/gulp.ogg', 100, 1) // This is a new feature. Only available for oral vore currently.
+
+		//Unbirth
 			if(target.vorifice == "Unbirth")
 				user.visible_message("<span class='danger'>[user] starts to push [M] into [target]'s pussy!</span>")
+
 				if(!do_mob(user, M)||!do_after(user, 100)) return
+
 				user.visible_message("<span class='danger'>The last of [M] vanishes into [target]'s vagina!</span>")
 				playsound(src, 'sound/vore/insert.ogg', 100, 1)
+
 				M.loc = target
-				src.contents.Remove(M)
 				target.womb_contents.Add(M)
+
 				if(target == user)
 					msg_admin_attack("[key_name(user)] unbirthed [key_name(M)]")
 				else
 					msg_admin_attack("[key_name(user)] forced [key_name(target)] to unbirth [key_name(M)]")
+
+		//Cock Vore
 			if(target.vorifice == "Cock Vore")
 				user.visible_message("<span class='danger'>[user] begins to force [M] down [target]'s shaft!</span>")
+
 				if(!do_mob(user, M)||!do_after(user, 100)) return
+
 				user.visible_message("<span class='danger'>[M] disappears into [target]'s cock!</span>")
+
 				M.loc = target
-				src.contents.Remove(M)
 				target.cock_contents.Add(M)
+
 				if(target == user)
 					msg_admin_attack("[key_name(user)] cock vored [key_name(M)]")
 				else
 					msg_admin_attack("[key_name(user)] forced [key_name(target)] to cock vore [key_name(M)]")
+
 				playsound(src, 'sound/vore/gulp.ogg', 100, 1)
+
+		//Anal Vore
 			if(target.vorifice == "Anal Vore")
 				user.visible_message("<span class='danger'>[user] starts sliding [M] up [target]'s ass!</span>")
+
 				if(!do_mob(user, M)||!do_after(user, 100)) return
+
 				user.visible_message("<span class='danger'>[M] fully slides into [target]'s ass!</span>")
+
 				M.loc = target
-				src.contents.Remove(M)
 				target.stomach_contents.Add(M)
+
 				if(target == user)
 					msg_admin_attack("[key_name(user)] anal vored [key_name(M)]")
 				else
 					msg_admin_attack("[key_name(user)] forced [key_name(target)] to anal vore [key_name(M)]")
+
 				playsound(src, 'sound/vore/schlorp.ogg', 100, 1)
+
+		//Breast Vore
 			if(target.vorifice == "Breast Vore")
 				user.visible_message("<span class='danger'>[user] is trying to force [M] into [target]'s breasts!</span>")
+
 				if(!do_mob(user, M)||!do_after(user, 100)) return
+
 				user.visible_message("<span class='danger'>[user] stuffs the last of [M] into [target]'s boobs!</span>")
+
 				M.loc = target
-				src.contents.Remove(M)
 				target.boob_contents.Add(M)
+
 				if(target == user)
 					msg_admin_attack("[key_name(user)] breast vored [key_name(M)]")
 				else
 					msg_admin_attack("[key_name(user)] forced [key_name(target)] to breast vore [key_name(M)]")
+
 				playsound(src, 'sound/vore/insert.ogg', 100, 1)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -62,135 +62,132 @@
  */
 
 //Vore code, struggle stuff
-mob/living/carbon/relaymove(var/mob/user, direction)
+/mob/living/carbon/relaymove(var/mob/user, var/direction)
 	var/struggle_sound // To randomize the squishy noises when prey struggles.
 	var/struggle_message // To randomize emotes.
 	var/recent_struggle = 0 // To prevent spammage
-	if(user in src.stomach_contents)
-		if(prob(40) && !recent_struggle)
-			recent_struggle = 1
-			for(var/mob/M in hearers(4, src)) //for(var/mob/M in viewers(user, null)) // <- This only works from the prey's POV.
-				if(M.client)
-					var/stomach = pick("stomach","gut","tummy","belly")// To randomize the word for 'stomach'
-					struggle_message = rand(1,8) // Increase this number per emote.
-					switch(struggle_message)
-						if(1)
-							M.show_message(text("\red [src]'s [stomach] wobbles with a squirming meal."), 2)
-							user << "\red You squirm inside of [src]'s [stomach], making it wobble around."
-						if(2)
-							M.show_message(text("\red [src]'s [stomach] jostles with movement."), 2)
-							user << "\red You jostle [src]'s [stomach] with movement."
-						if(3)
-							M.show_message(text("\red [src]'s [stomach] briefly swells outward as someone pushes from inside."), 2)
-							user << "\red You shove against the walls of [src]'s [stomach], making it briefly swell outward."
-						if(4)
-							M.show_message(text("\red [src]'s [stomach] fidgets with a trapped victim."), 2)
-							user << "\red You fidget around inside of [src]'s [stomach]."
-						if(5)
-							M.show_message(text("\red [src]'s [stomach] jiggles with motion from inside."), 2)
-							user << "\red Your motion causes [src]'s [stomach] to jiggle."
-						if(6)
-							M.show_message(text("\red [src]'s [stomach] sloshes around."), 2)
-							user << "\red Your movement only causes [src]'s [stomach] to slosh around you."
-						if(7)
-							M.show_message(text("\red [src]'s [stomach] gushes softly."), 2)
-							user << "\red Your struggles only cause [src]'s [stomach] to gush softly around you."
-						if(8)
-							M.show_message(text("\red [src]'s [stomach] lets out a wet squelch."), 2)
-							user << "\red Your useless squirming only causes [src]'s slimy [stomach] to squelch over your body."
-					struggle_sound = rand(1,4) // Increase this number per sound.
-					switch(struggle_sound)
-						if(1)
-							playsound(user.loc, 'sound/vore/squish1.ogg', 50, 1)
-						if(2)
-							playsound(user.loc, 'sound/vore/squish2.ogg', 50, 1)
-						if(3)
-							playsound(user.loc, 'sound/vore/squish3.ogg', 50, 1)
-						if(4)
-							playsound(user.loc, 'sound/vore/squish4.ogg', 50, 1)
-				spawn(20)
-					recent_struggle = 0
 
-	if(user in src.womb_contents)
-		if(prob(40) && !recent_struggle)
-			recent_struggle = 1
-			for(var/mob/M in hearers(4, src)) //for(var/mob/M in viewers(user, null)) // <- This only works from the prey's POV.
-				if(M.client)
-					struggle_message = rand(1,3) // Increase this number per emote
-					switch(struggle_message)
-						if(1)
-							M.show_message(text("\red [src]'s pregnant belly squirms with movement."), 2)
-							user << "\red You squirm inside of [src]'s pregnant belly."
-						if(2)
-							M.show_message(text("\red [src]'s swollen womb wriggles with movement."), 2)
-							user << "\red You wriggle inside of [src]'s womb."
-						if(3)
-							M.show_message(text("\red [src]'s lower tummy writhes around"), 2)
-							user << "\red You writhe inside of [src]'s lower tummy."
-					struggle_sound = rand(1,3) // Increase this number per sound.
-					switch(struggle_sound)
-						if(1)
-							playsound(user.loc, 'sound/vore/insertion1.ogg', 50, 1)
-						if(2)
-							playsound(user.loc, 'sound/vore/insertion2.ogg', 50, 1)
-						if(3)
-							playsound(user.loc, 'sound/vore/insertion3.ogg', 50, 1)
-				spawn(20)
-					recent_struggle = 0
+	if(recent_struggle)	return
 
-	if(user in src.cock_contents)
-		if(prob(40) && !recent_struggle)
-			recent_struggle = 1
-			for(var/mob/M in hearers(4, src)) //for(var/mob/M in viewers(user, null)) // <- This only works from the prey's POV.
-				if(M.client)
-					struggle_message = rand(1,3) // Increase this number per emote.
-					switch(struggle_message)
-						if(1)
-							M.show_message(text("\red [src]'s oversized balls sway with movement."), 2)
-							user << "\red You cause [src]'s oversized balls to sway with movement."
-						if(2)
-							M.show_message(text("\red [src]'s gorged sack wobbles with someone inside."), 2)
-							user << "\red You wobble around inside of [src]'s gorged sack."
-						if(3)
-							M.show_message(text("\red [src]'s swollen testicles bounce and squirm."), 2)
-							user << "\red You bounce and squirm within [src]'s swollen testicles."
-					struggle_sound = rand(1,3) // Increase this number per sound.
-					switch(struggle_sound)
-						if(1)
-							playsound(user.loc, 'sound/vore/insertion1.ogg', 50, 1)
-						if(2)
-							playsound(user.loc, 'sound/vore/insertion2.ogg', 50, 1)
-						if(3)
-							playsound(user.loc, 'sound/vore/insertion3.ogg', 50, 1)
-				spawn(20)
-					recent_struggle = 0
+	if(user in stomach_contents || user in womb_contents || user in cock_contents || user in boob_contents) //Cooldown
+		recent_struggle = 1
+		spawn(20)
+			recent_struggle = 0
 
-	if(user in src.boob_contents)
-		if(prob(40) && !recent_struggle)
-			recent_struggle = 1
-			for(var/mob/M in hearers(4, src)) //for(var/mob/M in viewers(user, null)) // <- This only works from the prey's POV.
-				if(M.client)
-					struggle_message = rand(1,3) // Increase this number per emote.
-					switch(struggle_message)
-						if(1)
-							M.show_message(text("\red [src]'s bust jostles abruptly."), 2)
-							user << "\red You jostle [src]'s bust up and down."
-						if(2)
-							M.show_message(text("\red [src]'s massive breasts jiggle and sway."), 2)
-							user << "\red Your squirmy movement makes [src]'s breasts jiggle and sway."
-						if(3)
-							M.show_message(text("\red [src]'s plump boobs wobble and bounce."), 2)
-							user << "\red You cause [src]'s boobs to wobble and bounce."
-					struggle_sound = rand(1,3) // Increase this number per sound.
-					switch(struggle_sound)
-						if(1)
-							playsound(user.loc, 'sound/vore/insertion1.ogg', 50, 1)
-						if(2)
-							playsound(user.loc, 'sound/vore/insertion2.ogg', 50, 1)
-						if(3)
-							playsound(user.loc, 'sound/vore/insertion3.ogg', 50, 1)
-				spawn(20)
-					recent_struggle = 0
+	if(user in stomach_contents)
+		if(prob(40))
+
+			var/stomach_noun = pick("stomach","gut","tummy","belly")// To randomize the word for 'stomach'
+			struggle_message = rand(1,8) // Increase this number per emote.
+			switch(struggle_message)
+				if(1)
+					audible_message("<span class='alert'>[src]'s [stomach_noun] wobbles with a squirming meal.</span>")
+					user << "<span class='alert'>You squirm inside of [src]'s [stomach_noun], making it wobble around.</span>"
+				if(2)
+					audible_message("<span class='alert'>[src]'s [stomach_noun] jostles with movement.</span>")
+					user << "<span class='alert'>You jostle [src]'s [stomach_noun] with movement.</span>"
+				if(3)
+					audible_message("<span class='alert'>[src]'s [stomach_noun] briefly swells outward as someone pushes from inside.</span>")
+					user << "<span class='alert'>You shove against the walls of [src]'s [stomach_noun], making it briefly swell outward.</span>"
+				if(4)
+					audible_message("<span class='alert'>[src]'s [stomach_noun] fidgets with a trapped victim.</span>")
+					user << "<span class='alert'>You fidget around inside of [src]'s [stomach_noun].</span>"
+				if(5)
+					audible_message("<span class='alert'>[src]'s [stomach_noun] jiggles with motion from inside.</span>")
+					user << "<span class='alert'>Your motion causes [src]'s [stomach_noun] to jiggle.</span>"
+				if(6)
+					audible_message("<span class='alert'>[src]'s [stomach_noun] sloshes around.</span>")
+					user << "<span class='alert'>Your movement only causes [src]'s [stomach_noun] to slosh around you.</span>"
+				if(7)
+					audible_message("<span class='alert'>[src]'s [stomach_noun] gushes softly.</span>")
+					user << "<span class='alert'>Your struggles only cause [src]'s [stomach_noun] to gush softly around you.</span>"
+				if(8)
+					audible_message("<span class='alert'>[src]'s [stomach_noun] lets out a wet squelch.</span>")
+					user << "<span class='alert'>Your useless squirming only causes [src]'s slimy [stomach_noun] to squelch over your body.</span>"
+
+			struggle_sound = rand(1,4) // Increase this number per sound.
+			switch(struggle_sound)
+				if(1)
+					playsound(user.loc, 'sound/vore/squish1.ogg', 50, 1)
+				if(2)
+					playsound(user.loc, 'sound/vore/squish2.ogg', 50, 1)
+				if(3)
+					playsound(user.loc, 'sound/vore/squish3.ogg', 50, 1)
+				if(4)
+					playsound(user.loc, 'sound/vore/squish4.ogg', 50, 1)
+
+	if(user in womb_contents)
+		if(prob(40))
+
+			struggle_message = rand(1,3) // Increase this number per emote
+			switch(struggle_message)
+				if(1)
+					audible_message("<span class='alert'>[src]'s pregnant belly squirms with movement.</span>")
+					user << "<span class='alert'>You squirm inside of [src]'s pregnant belly.</span>"
+				if(2)
+					audible_message("<span class='alert'>[src]'s swollen womb wriggles with movement.</span>")
+					user << "<span class='alert'>You wriggle inside of [src]'s womb.</span>"
+				if(3)
+					audible_message("<span class='alert'>[src]'s lower tummy writhes around.</span>")
+					user << "<span class='alert'>You writhe inside of [src]'s lower tummy.</span>"
+
+			struggle_sound = rand(1,3) // Increase this number per sound.
+			switch(struggle_sound)
+				if(1)
+					playsound(user.loc, 'sound/vore/insertion1.ogg', 50, 1)
+				if(2)
+					playsound(user.loc, 'sound/vore/insertion2.ogg', 50, 1)
+				if(3)
+					playsound(user.loc, 'sound/vore/insertion3.ogg', 50, 1)
+
+	if(user in cock_contents)
+		if(prob(40))
+
+			struggle_message = rand(1,3) // Increase this number per emote.
+			switch(struggle_message)
+				if(1)
+					audible_message("<span class='alert'>[src]'s oversized balls sway with movement.</span>")
+					user << "<span class='alert'>You cause [src]'s oversized balls to sway with movement.</span>"
+				if(2)
+					audible_message("<span class='alert'>[src]'s gorged sack wobbles with someone inside.</span>")
+					user << "<span class='alert'>You wobble around inside of [src]'s gorged sack.</span>"
+				if(3)
+					audible_message("<span class='alert'>[src]'s swollen testicles bounce and squirm.</span>")
+					user << "<span class='alert'>You bounce and squirm within [src]'s swollen testicles.</span>"
+
+			struggle_sound = rand(1,3) // Increase this number per sound.
+			switch(struggle_sound)
+				if(1)
+					playsound(user.loc, 'sound/vore/insertion1.ogg', 50, 1)
+				if(2)
+					playsound(user.loc, 'sound/vore/insertion2.ogg', 50, 1)
+				if(3)
+					playsound(user.loc, 'sound/vore/insertion3.ogg', 50, 1)
+
+	if(user in boob_contents)
+		if(prob(40))
+
+			struggle_message = rand(1,3) // Increase this number per emote.
+			switch(struggle_message)
+				if(1)
+					audible_message("<span class='alert'>[src]'s bust jostles abruptly.</span>")
+					user << "<span class='alert'>You jostle [src]'s bust up and down.</span>"
+				if(2)
+					audible_message("<span class='alert'>[src]'s massive breasts jiggle and sway.</span>")
+					user << "<span class='alert'>Your squirmy movement makes [src]'s breasts jiggle and sway.</span>"
+				if(3)
+					audible_message("<span class='alert'>[src]'s plump boobs wobble and bounce.</span>")
+					user << "<span class='alert'>You cause [src]'s boobs to wobble and bounce.</span>"
+
+			//This isn't part of the for loop. It just plays a sound once.
+			struggle_sound = rand(1,3) // Increase this number per sound.
+			switch(struggle_sound)
+				if(1)
+					playsound(user.loc, 'sound/vore/insertion1.ogg', 50, 1)
+				if(2)
+					playsound(user.loc, 'sound/vore/insertion2.ogg', 50, 1)
+				if(3)
+					playsound(user.loc, 'sound/vore/insertion3.ogg', 50, 1)
 
 /mob/living/carbon/gib()
 	for(var/mob/M in src)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -202,7 +202,7 @@
 		M.loc = src.loc
 		for(var/mob/N in viewers(src, null))
 			if(N.client)
-				N.show_message(text("\red <B>[M] bursts out of [src]!</B>"), 2)
+				N.show_message(text("<span class='danger'>[M] bursts out of [src]!</span>"), 2)
 	. = ..()
 //End vore script.
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -61,49 +61,58 @@
 	..()
  */
 
+/mob/living/carbon
+	var/recent_struggle = 0 // To prevent spammage
+
 //Vore code, struggle stuff
 /mob/living/carbon/relaymove(var/mob/user, var/direction)
 	var/struggle_sound // To randomize the squishy noises when prey struggles.
 	var/struggle_message // To randomize emotes.
-	var/recent_struggle = 0 // To prevent spammage
 
-	if(recent_struggle)	return
+	var/struggle_outer_message
+	var/struggle_user_message
 
-	if(user in stomach_contents || user in womb_contents || user in cock_contents || user in boob_contents) //Cooldown
-		recent_struggle = 1
-		spawn(20)
-			recent_struggle = 0
+	if(recent_struggle) return
+
+	recent_struggle = 1
+	spawn(20)
+		recent_struggle = 0
 
 	if(user in stomach_contents)
 		if(prob(40))
 
 			var/stomach_noun = pick("stomach","gut","tummy","belly")// To randomize the word for 'stomach'
 			struggle_message = rand(1,8) // Increase this number per emote.
+
 			switch(struggle_message)
 				if(1)
-					audible_message("<span class='alert'>[src]'s [stomach_noun] wobbles with a squirming meal.</span>")
-					user << "<span class='alert'>You squirm inside of [src]'s [stomach_noun], making it wobble around.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s [stomach_noun] wobbles with a squirming meal.</span>"
+					struggle_user_message = "<span class='alert'>You squirm inside of [src]'s [stomach_noun], making it wobble around.</span>"
 				if(2)
-					audible_message("<span class='alert'>[src]'s [stomach_noun] jostles with movement.</span>")
-					user << "<span class='alert'>You jostle [src]'s [stomach_noun] with movement.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s [stomach_noun] jostles with movement.</span>"
+					struggle_user_message = "<span class='alert'>You jostle [src]'s [stomach_noun] with movement.</span>"
 				if(3)
-					audible_message("<span class='alert'>[src]'s [stomach_noun] briefly swells outward as someone pushes from inside.</span>")
-					user << "<span class='alert'>You shove against the walls of [src]'s [stomach_noun], making it briefly swell outward.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s [stomach_noun] briefly swells outward as someone pushes from inside.</span>"
+					struggle_user_message = "<span class='alert'>You shove against the walls of [src]'s [stomach_noun], making it briefly swell outward.</span>"
 				if(4)
-					audible_message("<span class='alert'>[src]'s [stomach_noun] fidgets with a trapped victim.</span>")
-					user << "<span class='alert'>You fidget around inside of [src]'s [stomach_noun].</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s [stomach_noun] fidgets with a trapped victim.</span>"
+					struggle_user_message = "<span class='alert'>You fidget around inside of [src]'s [stomach_noun].</span>"
 				if(5)
-					audible_message("<span class='alert'>[src]'s [stomach_noun] jiggles with motion from inside.</span>")
-					user << "<span class='alert'>Your motion causes [src]'s [stomach_noun] to jiggle.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s [stomach_noun] jiggles with motion from inside.</span>"
+					struggle_user_message = "<span class='alert'>Your motion causes [src]'s [stomach_noun] to jiggle.</span>"
 				if(6)
-					audible_message("<span class='alert'>[src]'s [stomach_noun] sloshes around.</span>")
-					user << "<span class='alert'>Your movement only causes [src]'s [stomach_noun] to slosh around you.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s [stomach_noun] sloshes around.</span>"
+					struggle_user_message = "<span class='alert'>Your movement only causes [src]'s [stomach_noun] to slosh around you.</span>"
 				if(7)
-					audible_message("<span class='alert'>[src]'s [stomach_noun] gushes softly.</span>")
-					user << "<span class='alert'>Your struggles only cause [src]'s [stomach_noun] to gush softly around you.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s [stomach_noun] gushes softly.</span>"
+					struggle_user_message = "<span class='alert'>Your struggles only cause [src]'s [stomach_noun] to gush softly around you.</span>"
 				if(8)
-					audible_message("<span class='alert'>[src]'s [stomach_noun] lets out a wet squelch.</span>")
-					user << "<span class='alert'>Your useless squirming only causes [src]'s slimy [stomach_noun] to squelch over your body.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s [stomach_noun] lets out a wet squelch.</span>"
+					struggle_user_message = "<span class='alert'>Your useless squirming only causes [src]'s slimy [stomach_noun] to squelch over your body.</span>"
+
+			for(var/mob/M in hearers(4,src))
+				M.show_message(struggle_outer_message, 2) //hearable
+			user << struggle_user_message
 
 			struggle_sound = rand(1,4) // Increase this number per sound.
 			switch(struggle_sound)
@@ -122,14 +131,18 @@
 			struggle_message = rand(1,3) // Increase this number per emote
 			switch(struggle_message)
 				if(1)
-					audible_message("<span class='alert'>[src]'s pregnant belly squirms with movement.</span>")
-					user << "<span class='alert'>You squirm inside of [src]'s pregnant belly.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s pregnant belly squirms with movement.</span>"
+					struggle_user_message = "<span class='alert'>You squirm inside of [src]'s pregnant belly.</span>"
 				if(2)
-					audible_message("<span class='alert'>[src]'s swollen womb wriggles with movement.</span>")
-					user << "<span class='alert'>You wriggle inside of [src]'s womb.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s swollen womb wriggles with movement.</span>"
+					struggle_user_message = "<span class='alert'>You wriggle inside of [src]'s womb.</span>"
 				if(3)
-					audible_message("<span class='alert'>[src]'s lower tummy writhes around.</span>")
-					user << "<span class='alert'>You writhe inside of [src]'s lower tummy.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s lower tummy writhes around.</span>"
+					struggle_user_message = "<span class='alert'>You writhe inside of [src]'s lower tummy.</span>"
+
+			for(var/mob/M in hearers(4,src))
+				M.show_message(struggle_outer_message, 2) //hearable
+			user << struggle_user_message
 
 			struggle_sound = rand(1,3) // Increase this number per sound.
 			switch(struggle_sound)
@@ -146,14 +159,18 @@
 			struggle_message = rand(1,3) // Increase this number per emote.
 			switch(struggle_message)
 				if(1)
-					audible_message("<span class='alert'>[src]'s oversized balls sway with movement.</span>")
-					user << "<span class='alert'>You cause [src]'s oversized balls to sway with movement.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s oversized balls sway with movement.</span>"
+					struggle_user_message = "<span class='alert'>You cause [src]'s oversized balls to sway with movement.</span>"
 				if(2)
-					audible_message("<span class='alert'>[src]'s gorged sack wobbles with someone inside.</span>")
-					user << "<span class='alert'>You wobble around inside of [src]'s gorged sack.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s gorged sack wobbles with someone inside.</span>"
+					struggle_user_message = "<span class='alert'>You wobble around inside of [src]'s gorged sack.</span>"
 				if(3)
-					audible_message("<span class='alert'>[src]'s swollen testicles bounce and squirm.</span>")
-					user << "<span class='alert'>You bounce and squirm within [src]'s swollen testicles.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s swollen testicles bounce and squirm.</span>"
+					struggle_user_message = "<span class='alert'>You bounce and squirm within [src]'s swollen testicles.</span>"
+
+			for(var/mob/M in hearers(4,src))
+				M.show_message(struggle_outer_message, 2) //hearable
+			user << struggle_user_message
 
 			struggle_sound = rand(1,3) // Increase this number per sound.
 			switch(struggle_sound)
@@ -170,14 +187,18 @@
 			struggle_message = rand(1,3) // Increase this number per emote.
 			switch(struggle_message)
 				if(1)
-					audible_message("<span class='alert'>[src]'s bust jostles abruptly.</span>")
-					user << "<span class='alert'>You jostle [src]'s bust up and down.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s bust jostles abruptly.</span>"
+					struggle_user_message = "<span class='alert'>You jostle [src]'s bust up and down.</span>"
 				if(2)
-					audible_message("<span class='alert'>[src]'s massive breasts jiggle and sway.</span>")
-					user << "<span class='alert'>Your squirmy movement makes [src]'s breasts jiggle and sway.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s massive breasts jiggle and sway.</span>"
+					struggle_user_message = "<span class='alert'>Your squirmy movement makes [src]'s breasts jiggle and sway.</span>"
 				if(3)
-					audible_message("<span class='alert'>[src]'s plump boobs wobble and bounce.</span>")
-					user << "<span class='alert'>You cause [src]'s boobs to wobble and bounce.</span>"
+					struggle_outer_message = "<span class='alert'>[src]'s plump boobs wobble and bounce.</span>"
+					struggle_user_message = "<span class='alert'>You cause [src]'s boobs to wobble and bounce.</span>"
+
+			for(var/mob/M in hearers(4,src))
+				M.show_message(struggle_outer_message, 2) //hearable
+			user << struggle_user_message
 
 			//This isn't part of the for loop. It just plays a sound once.
 			struggle_sound = rand(1,3) // Increase this number per sound.

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -1,10 +1,12 @@
 /mob/living/carbon/
 	gender = MALE
 	var/datum/species/species //Contains icon generation and language information, set during New().
+
 	var/list/stomach_contents = list()
 	var/list/womb_contents = list() //
 	var/list/cock_contents = list() //   Vore code.
 	var/list/boob_contents = list() //
+
 	var/list/datum/disease2/disease/virus2 = list()
 	var/list/antibodies = list()
 	var/last_eating = 0 	//Not sure what this does... I found it hidden in food.dm

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -785,17 +785,29 @@
 			spawn(100)	//and you have 10 more for mad dash to the bucket
 				Stun(5)
 
-				src.visible_message("<spawn class='warning'>[src] throws up!</span>","<spawn class='warning'>You throw up!</span>")
-				if(stomach_contents.len) // Vore code. Copied from vore.dm, so people in your belly get spat out if you puke.
-					for(var/mob/M in src)
-						if(M in stomach_contents)
-							stomach_contents.Remove(M)
-							for (var/mob/living/carbon/R in hearers(src.loc, null))
-								if(src in R.stomach_contents)
-									M.loc = R.stomach_contents
-								else
-									M.loc = loc
-					src.visible_message("\green <B>[src] also hurls out the contents of their stomach!</B>")
+				src.visible_message("<span class='warning'>[src] throws up!</span>","<span class='warning'>You throw up!</span>")
+
+				/* Force any mob to exit their stomach. */
+				if(stomach_contents.len)
+					for(var/mob/M in stomach_contents)
+
+						M.loc = src.loc //this is specifically defined as src.loc to try to prevent a mob from ending up in nullspace by byond confusion
+						stomach_contents.Remove(M)
+
+						if(iscarbon(src.loc)) //This makes sure that the mob behaves properly if released into another mob
+							var/mob/living/carbon/loc_mob = src.loc
+
+							if(src in loc_mob.stomach_contents)
+								loc_mob.stomach_contents += M
+							if(src in loc_mob.womb_contents)
+								loc_mob.womb_contents += M
+							if(src in loc_mob.cock_contents)
+								loc_mob.cock_contents += M
+							if(src in loc_mob.boob_contents)
+								loc_mob.boob_contents += M
+
+					visible_message("<font color='green'><b>[src] also hurls out the contents of their stomach!</b></font>")
+
 				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 
 				var/turf/location = loc

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1472,7 +1472,7 @@
 						continue
 
 				if(stat != DEAD && stendo) //According to vore.dm, stendo being true means people should digest. // also: For some reason this can't be checked in the if statement below.
-					if(iscarbon(M) || isanimal(M) // If human or simple mob and you're set to digest.
+					if(iscarbon(M) || isanimal(M)) // If human or simple mob and you're set to digest.
 						if(M.stat == DEAD)
 							M.death(1)
 							stomach_contents.Remove(M)
@@ -1547,7 +1547,7 @@
 						continue
 
 				if(stat != DEAD && cvendo) // For some reason this can't be checked in the if statement below.
-					if(iscarbon(M) || isanimal(M) // If human or simple mob and you're set to digest.
+					if(iscarbon(M) || isanimal(M)) // If human or simple mob and you're set to digest.
 						if(M.stat == DEAD)
 							cockfull = 1
 							M.death(1)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -332,6 +332,7 @@
 		if(istype(loc, /obj/machinery/atmospherics/unary/cryo_cell)) return
 		if(species && (species.flags & NO_BREATHE || species.flags & IS_SYNTHETIC)) return
 		if(istype(loc, /obj/item/weapon/holder/micro)) return
+		if(ismob(loc))	return //otherwise return_air will return nothing and therefore immediately suffocate them
 
 		var/datum/gas_mixture/environment = loc.return_air()
 		var/datum/gas_mixture/breath

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1465,13 +1465,15 @@
 				if(M.loc != src)
 					stomach_contents.Remove(M)
 					continue
+
 				if(istype(M, /mob/living/carbon/human))
 					var/mob/living/carbon/human/R = M
 					if(R.digestable == 0)
 						continue
-				if(stat != 2 && stendo != 1) // For some reason this can't be checked in the if statement below.
-					if(istype(M, /mob/living/carbon) || istype(M, /mob/living/simple_animal)) // If human or simple mob and you're set to digest.
-						if(M.stat == 2)
+
+				if(stat != DEAD && stendo) //According to vore.dm, stendo being true means people should digest. // also: For some reason this can't be checked in the if statement below.
+					if(iscarbon(M) || isanimal(M) // If human or simple mob and you're set to digest.
+						if(M.stat == DEAD)
 							M.death(1)
 							stomach_contents.Remove(M)
 							digest_alert = rand(1,9) // Increase this number per emote.
@@ -1524,25 +1526,29 @@
 							nutrition += 20 // so eating dead mobs gives you *something*.
 							del(M)
 							continue
+
 						if(air_master.current_cycle%3==1)
 							if(!(M.status_flags & GODMODE))
 								M.adjustBruteLoss(2)
 								M.adjustFireLoss(3)
 								var/difference = src.playerscale / M.playerscale 	// LOOK HOW FUCKING CLEVER I AM.
 								nutrition += 10/difference 							// I AM SO PROUD OF MYSELF. -Ace 	 PROUD OF YOU -NW.
+
 	proc/handle_cock()
 		spawn(0)
 			for(var/mob/living/M in cock_contents)
 				if(M.loc != src)
 					cock_contents.Remove(M)
 					continue
+
 				if(istype(M, /mob/living/carbon/human))
 					var/mob/living/carbon/human/R = M
 					if(R.digestable == 0)
 						continue
-				if(stat != 2 && cvendo != 1) // For some reason this can't be checked in the if statement below.
-					if(istype(M, /mob/living/carbon) || istype(M, /mob/living/simple_animal)) // If human or simple mob and you're set to digest.
-						if(M.stat == 2)
+
+				if(stat != DEAD && cvendo) // For some reason this can't be checked in the if statement below.
+					if(iscarbon(M) || isanimal(M) // If human or simple mob and you're set to digest.
+						if(M.stat == DEAD)
 							cockfull = 1
 							M.death(1)
 							cock_contents.Remove(M)
@@ -1550,23 +1556,27 @@
 							M << "<span class='notice'>You dissolve into hot cum in [src]'s throbbing, swollen groin.</span>"
 							del(M)
 							continue
+
 						if(air_master.current_cycle%3==1)
 							if(!(M.status_flags & GODMODE))
 								M.adjustBruteLoss(2)
 								M.adjustFireLoss(3)
+
 	proc/handle_boob()
 		spawn(0)
 			for(var/mob/living/M in boob_contents)
 				if(M.loc != src)
 					boob_contents.Remove(M)
 					continue
+
 				if(istype(M, /mob/living/carbon/human))
 					var/mob/living/carbon/human/R = M
 					if(R.digestable == 0)
 						continue
-				if(stat != 2 && bvendo != 1) // For some reason this can't be checked in the if statement below.
-					if(istype(M, /mob/living/carbon) || istype(M, /mob/living/simple_animal)) // If human or simple mob and you're set to digest.
-						if(M.stat == 2)
+
+				if(stat != DEAD && bvendo) // For some reason this can't be checked in the if statement below.
+					if(iscarbon(M) || isanimal(M)) // If human or simple mob and you're set to digest.
+						if(M.stat == DEAD)
 							boobfull = 1
 							M.death(1)
 							boob_contents.Remove(M)
@@ -1574,17 +1584,21 @@
 							M << "<span class='notice'>You melt into creamy milk, leaving [src]'s breasts full and jiggling.</span>"
 							del(M)
 							continue
+
 						if(air_master.current_cycle%3==1)
 							if(!(M.status_flags & GODMODE))
 								M.adjustBruteLoss(2)
 								M.adjustFireLoss(3)
+
 	proc/handle_womb() // TODO: Make simple mobs work here. // TODO: Optimize the ever living fuck out of this horrible code.
 		spawn(0)
 			for(var/mob/living/M in womb_contents)
 				if(M.loc != src)
 					womb_contents.Remove(M)
 					continue
-				if(istype(M, /mob/living/carbon) && stat != 2 && wombheal == "Heal" && M.stat != 2)
+
+			//WOMB HEAL
+				if(iscarbon(M) && stat != DEAD && wombheal == "Heal" && M.stat != DEAD)
 					if(air_master.current_cycle%3==1)
 						if(!(M.status_flags & GODMODE))
 							if(nutrition > 90)
@@ -1593,12 +1607,14 @@
 								nutrition -= 2
 								if(M.nutrition <= 400)
 									M.nutrition += 1
-				if(istype(M, /mob/living/carbon) && stat != 2 && wombheal == "Digest")
+
+			//WOMB DIGEST
+				if(iscarbon(M) && stat != DEAD && wombheal == "Digest")
 					if(istype(M, /mob/living/carbon/human))
 						var/mob/living/carbon/human/R = M
 						if(R.digestable == 0)
 							continue
-					if(M.stat == 2)
+					if(M.stat == DEAD)
 						wombfull = 1
 						M.death(1)
 						womb_contents.Remove(M)
@@ -1610,12 +1626,17 @@
 						if(!(M.status_flags & GODMODE))
 							M.adjustBruteLoss(2)
 							M.adjustFireLoss(3)
-				if(istype(M, /mob/living/carbon/human) && stat != 2 && wombheal == "Transform (Female)" && M.stat != 2)
+
+			//WOMB TRANSFORM (FEM)
+				if(ishuman(M) && stat != DEAD && wombheal == "Transform (Female)" && M.stat != DEAD)
 					var/mob/living/carbon/human/P = M
+
 					if(air_master.current_cycle%3==1)
 						if(!(M.status_flags & GODMODE))
+
 							var/TFchance = prob(10)
 							if(TFchance == 1)
+
 								var/TFmodify = rand(1,3)
 								if(TFmodify == 1 && P.r_eyes != src.r_eyes && P.g_eyes != src.g_eyes && P.b_eyes != src.b_eyes)
 									P.r_eyes = src.r_eyes
@@ -1624,6 +1645,7 @@
 									P << "<span class='notice'>You feel lightheaded and drowsy...</span>"
 									src << "<span class='notice'>Your belly feels warm as your womb makes subtle changes to your captive's body.</span>"
 									P.update_body()
+
 								if(TFmodify == 2 && P.r_hair != src.r_hair && P.g_hair != src.g_hair && P.b_hair != src.b_hair && P.r_skin != src.r_skin && P.g_skin != src.g_skin && P.b_skin != src.b_skin)
 									P.r_hair = src.r_hair
 									P.g_hair = src.g_hair
@@ -1635,24 +1657,32 @@
 									P << "<span class='notice'>Your body tingles all over...</span>"
 									src << "<span class='notice'>Your belly tingles as your womb makes noticeable changes to your captive's body.</span>"
 									P.update_hair()
+
 								if(TFmodify == 3 && P.gender != FEMALE)
 									P.f_style = "Shaved"
 									P.gender = FEMALE
 									P << "<span class='notice'>Your body feels very strange...</span>"
 									src << "<span class='notice'>Your belly feels strange as your womb alters your captive's gender.</span>"
 									P.update_body()
+
 							M.adjustBruteLoss(-1)
 							M.adjustFireLoss(-1)
+
 							if(nutrition > 0)
 								nutrition -= 2
 							if(P.nutrition < 400)
 								P.nutrition += 1
-				if(istype(M, /mob/living/carbon/human) && stat != 2 && wombheal == "Transform (Male)" && M.stat != 2)
+
+			//WOMB TRANSFORM (MALE)
+				if(ishuman(M) && stat != DEAD && wombheal == "Transform (Male)" && M.stat != DEAD)
 					var/mob/living/carbon/human/P = M
+
 					if(air_master.current_cycle%3==1)
 						if(!(M.status_flags & GODMODE))
+
 							var/TFchance = prob(10)
 							if(TFchance == 1)
+
 								var/TFmodify = rand(1,3)
 								if(TFmodify == 1 && P.r_eyes != src.r_eyes && P.g_eyes != src.g_eyes && P.b_eyes != src.b_eyes)
 									P.r_eyes = src.r_eyes
@@ -1661,6 +1691,7 @@
 									P << "<span class='notice'>You feel lightheaded and drowsy...</span>"
 									src << "<span class='notice'>Your belly feels warm as your womb makes subtle changes to your captive's body.</span>"
 									P.update_body()
+
 								if(TFmodify == 2 && P.r_hair != src.r_hair && P.g_hair != src.g_hair && P.b_hair != src.b_hair && P.r_skin != src.r_skin && P.g_skin != src.g_skin && P.b_skin != src.b_skin)
 									P.r_hair = src.r_hair
 									P.r_facial = src.r_hair
@@ -1675,23 +1706,31 @@
 									P << "<span class='notice'>Your body tingles all over...</span>"
 									src << "<span class='notice'>Your belly tingles as your womb makes noticeable changes to your captive's body.</span>"
 									P.update_hair()
+
 								if(TFmodify == 3 && P.gender != MALE)
 									P.gender = MALE
 									P << "<span class='notice'>Your body feels very strange...</span>"
 									src << "<span class='notice'>Your belly feels strange as your womb alters your captive's gender.</span>"
 									P.update_body()
+
 							M.adjustBruteLoss(-1)
 							M.adjustFireLoss(-1)
+
 							if(nutrition > 0)
 								nutrition -= 2
 							if(P.nutrition < 400)
 								P.nutrition += 1
-				if(istype(M, /mob/living/carbon/human) && stat != 2 && wombheal == "Transform (Keep Gender)" && M.stat != 2)
+
+			//WOMB TRANSFORM (KEEP GENDER)
+				if(ishuman(M) && stat != DEAD && wombheal == "Transform (Keep Gender)" && M.stat != DEAD)
 					var/mob/living/carbon/human/P = M
+
 					if(air_master.current_cycle%3==1)
 						if(!(M.status_flags & GODMODE))
+
 							var/TFchance = prob(10)
 							if(TFchance == 1)
+
 								var/TFmodify = rand(1,2)
 								if(TFmodify == 1 && P.r_eyes != src.r_eyes && P.g_eyes != src.g_eyes && P.b_eyes != src.b_eyes)
 									P.r_eyes = src.r_eyes
@@ -1700,6 +1739,7 @@
 									P << "<span class='notice'>You feel lightheaded and drowsy...</span>"
 									src << "<span class='notice'>Your belly feels warm as your womb makes subtle changes to your captive's body.</span>"
 									P.update_body()
+
 								if(TFmodify == 2 && P.r_hair != src.r_hair && P.g_hair != src.g_hair && P.b_hair != src.b_hair && P.r_skin != src.r_skin && P.g_skin != src.g_skin && P.b_skin != src.b_skin)
 									P.r_hair = src.r_hair
 									P.r_facial = src.r_hair
@@ -1714,18 +1754,25 @@
 									P << "<span class='notice'>Your body tingles all over...</span>"
 									src << "<span class='notice'>Your belly tingles as your womb makes noticeable changes to your captive's body.</span>"
 									P.update_hair()
+
 							M.adjustBruteLoss(-1)
 							M.adjustFireLoss(-1)
+
 							if(nutrition > 0)
 								nutrition -= 2
 							if(P.nutrition < 400)
 								P.nutrition += 1
-				if(istype(M, /mob/living/carbon/human) && stat != 2 && wombheal == "Transform (Change Species)" && M.stat != 2)
+
+			//WOMB TRANSFORM (CHANGE SPECIES)
+				if(ishuman(M) && stat != DEAD && wombheal == "Transform (Change Species)" && M.stat != DEAD)
 					var/mob/living/carbon/human/P = M
+
 					if(air_master.current_cycle%3==1)
 						if(!(M.status_flags & GODMODE))
+
 							var/TFchance = prob(10)
 							if(TFchance == 1)
+
 								var/TFmodify = rand(1,3)
 								if(TFmodify == 1 && P.r_eyes != src.r_eyes && P.g_eyes != src.g_eyes && P.b_eyes != src.b_eyes)
 									P.r_eyes = src.r_eyes
@@ -1734,6 +1781,7 @@
 									P << "<span class='notice'>You feel lightheaded and drowsy...</span>"
 									src << "<span class='notice'>Your belly feels warm as your womb makes subtle changes to your captive's body.</span>"
 									P.update_body()
+
 								if(TFmodify == 2 && P.r_hair != src.r_hair && P.g_hair != src.g_hair && P.b_hair != src.b_hair && P.r_skin != src.r_skin && P.g_skin != src.g_skin && P.b_skin != src.b_skin)
 									P.r_hair = src.r_hair
 									P.r_facial = src.r_hair
@@ -1751,6 +1799,7 @@
 									//Omitted clause : P.race_icon != src.race_icon
 									//No idea how to work with that one, species system got changed a lot
 									//Also this makes it similar to the previous one until fixed
+
 								if(TFmodify == 3 && P.r_hair != src.r_hair && P.g_hair != src.g_hair && P.b_hair != src.b_hair && P.r_skin != src.r_skin && P.g_skin != src.g_skin && P.b_skin != src.b_skin)
 									P.r_hair = src.r_hair
 									P.r_facial = src.r_hair
@@ -1769,8 +1818,10 @@
 									P << "<span class='notice'>You lose sensation of your body, feeling only the warmth of the womb...</span>"
 									src << "<span class='notice'>Your belly shifts as your womb makes dramatic changes to your captive's body.</span>"
 									P.update_hair()
+
 							M.adjustBruteLoss(-1)
 							M.adjustFireLoss(-1)
+
 							if(nutrition > 0)
 								nutrition -= 2
 							if(P.nutrition < 400)

--- a/code/modules/mob/mob_grab.dm
+++ b/code/modules/mob/mob_grab.dm
@@ -195,7 +195,8 @@
 
 	//This was added in by Bay, I don't know how it would work in practice
 
-	if(M == assailant && state >= GRAB_AGGRESSIVE)
+	//Bay eating code, covered by below proc.
+/*	if(M == assailant && state >= GRAB_AGGRESSIVE)
 
 		var/can_eat
 		if((FAT in user.mutations) && ismonkey(affecting))
@@ -218,7 +219,7 @@
 			user.visible_message("<span class='danger'>[user] devours [affecting]!</span>")
 			affecting.loc = user
 			attacker.stomach_contents.Add(affecting)
-			del(src)
+			del(src)*/
 
 //Vore code swallowing emotes, modifying existing alien vore stuff.
 	if(state >= GRAB_AGGRESSIVE)
@@ -238,131 +239,202 @@
 				/*if(istype(affecting,/mob/living/simple_animal/hostile) && affecting.health >= 0 && affecting.faction != user.faction) // You can't eat something trying to kill you!
 					user << "\red You can't eat that! It's still alive and still VERY PISSED OFF!"
 					break*/ //
+
+			//ORAL VORE
 				if(attacker.vorifice == "Oral Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to swallow down [affecting]!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[user] swallows the last of [affecting]!</span>")
+
 					affecting.loc = user
 					attacker.stomach_contents.Add(affecting)
+
 					msg_admin_attack("[key_name(user)] oral vored [key_name(affecting)]")
 					playsound(src, 'sound/vore/gulp.ogg', 100, 1)
+
 					del(src)
+
+			//UNBIRTH
 				if(attacker.vorifice == "Unbirth")
 					user.visible_message("<span class='danger'>[user] is attempting to unbirth [affecting]!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[user] squelches [affecting] into [pronoun] womb!</span>")
 					playsound(src, 'sound/vore/insert.ogg', 100, 1)
+
 					affecting.loc = user
 					attacker.womb_contents.Add(affecting)
+
 					msg_admin_attack("[key_name(user)] unbirthed [key_name(affecting)]")
+
 					del(src)
+
+			//COCK VORE
 				if(attacker.vorifice == "Cock Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to slide [affecting] into [pronoun] cock!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[user] swallows [affecting] with [pronoun] cock!</span>")
 					playsound(src, 'sound/vore/gulp.ogg', 100, 1)
+
 					affecting.loc = user
 					attacker.cock_contents.Add(affecting)
+
 					msg_admin_attack("[key_name(user)] cock vored [key_name(affecting)]")
+
 					del(src)
+
+			//ANAL VORE
 				if(attacker.vorifice == "Anal Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to push [affecting] up [pronoun] rear!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[user] schlorps [affecting] into [pronoun] rump!</span>")
 					playsound(src, 'sound/vore/schlorp.ogg', 100, 1)
+
 					affecting.loc = user
 					attacker.stomach_contents.Add(affecting)
+
 					msg_admin_attack("[key_name(user)] anal vored [key_name(affecting)]")
+
 					del(src)
+
+			//BREAST VORE
 				if(attacker.vorifice == "Breast Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to stuff [affecting] into [pronoun] breasts!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[user] sucks [affecting] into [pronoun] tits!</span>")
 					playsound(src, 'sound/vore/insert.ogg', 100, 1)
+
 					affecting.loc = user
 					attacker.boob_contents.Add(affecting)
+
 					msg_admin_attack("[key_name(user)] boob vored [key_name(affecting)]")
+
 					del(src)
 
 			// If you click your target...
 			if(M == affecting)
 				var/mob/living/carbon/attacker = user
 				var/mob/living/carbon/target = M
+
+			//ORAL VORE
 				if(attacker.vorifice == "Oral Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to feed themselves to [affecting]!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[affecting] swallows the last of [user]!</span>")
+
 					user.loc = affecting
 					target.stomach_contents.Add(user)
+
 					msg_admin_attack("[key_name(user)] fed themselves to [key_name(affecting)]")
 					playsound(src, 'sound/vore/gulp.ogg', 100, 1) // This is a new feature. Only available for oral vore currently.
-					//del(src)
+
+					del(src)
+
+
+			//UNBIRTH
 				if(attacker.vorifice == "Unbirth")
 					user.visible_message("<span class='danger'>[user] is attempting to climb into [affecting]'s pussy!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[user] squelches into [affecting]'s womb!</span>")
 					playsound(src, 'sound/vore/insert.ogg', 100, 1)
+
 					user.loc = affecting
 					target.womb_contents.Add(user)
+
 					msg_admin_attack("[key_name(user)] forced [key_name(affecting)] to unbirth them")
-					//del(src)
+
+					del(src)
+
+			//COCK VORE
 				if(attacker.vorifice == "Cock Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to slide into [affecting]'s cock!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[user] vanishes into [affecting]'s cock!</span>")
 					playsound(src, 'sound/vore/gulp.ogg', 100, 1)
+
 					user.loc = affecting
 					target.cock_contents.Add(user)
+
 					msg_admin_attack("[key_name(user)] forced [key_name(affecting)] to cock vore them")
-					//del(src)
+
+					del(src)
+
+			//ANAL VORE
 				if(attacker.vorifice == "Anal Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to push themselves up [affecting]'s rear!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[user] disappears up [affecting]'s ass!</span>")
 					playsound(src, 'sound/vore/schlorp.ogg', 100, 1)
+
 					user.loc = affecting
 					target.stomach_contents.Add(user)
+
 					msg_admin_attack("[key_name(user)] forced [key_name(affecting)] to anal vore them")
-					//del(src)
+					del(src)
+
+			//BREAST VORE
 				if(attacker.vorifice == "Breast Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to stuff themselves into [affecting]'s breasts!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[user] pushes themselves fully into [affecting]'s tits!</span>")
 					playsound(src, 'sound/vore/insert.ogg', 100, 1)
+
 					user.loc = affecting
 					target.boob_contents.Add(user)
+
 					msg_admin_attack("[key_name(user)] forced [key_name(affecting)] to boob vore them")
-					//del(src)
+
+					del(src)
+
 			// If you click someone else...
 			else
 				var/mob/living/carbon/attacker = user
@@ -371,66 +443,100 @@
 				/*if(istype(M,/mob/living/simple_animal/hostile) && M.health >= 0 && M.faction != user.faction) // You can't feed something to someone while it's trying to kill you!
 					user << "\red You can't feed that to [affecting]! It's still alive and still VERY PISSED OFF!"
 					break*/
+			//ORAL VORE
 				if(attacker.vorifice == "Oral Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to feed [affecting] to [M]!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[M] swallows the last of [affecting]!</span>")
+
 					affecting.loc = target
 					target.stomach_contents.Add(affecting)
+
 					msg_admin_attack("[key_name(user)] fed [key_name(affecting)] to [key_name(M)]")
 					playsound(src, 'sound/vore/gulp.ogg', 100, 1) // This is a new feature. Only available for oral vore currently.
-					//del(src)
+
+					del(src)
+
+			//UNBIRTH
 				if(attacker.vorifice == "Unbirth")
 					user.visible_message("<span class='danger'>[user] is attempting to push [affecting] into [M]'s pussy!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[affecting] squelches into [M]'s womb!</span>")
 					playsound(src, 'sound/vore/insert.ogg', 100, 1)
+
 					affecting.loc = target
 					target.womb_contents.Add(affecting)
+
 					msg_admin_attack("[key_name(user)] forced [key_name(M)] to unbirth [key_name(affecting)]")
-					//del(src)
+
+					del(src)
+
+			//COCK VORE
 				if(attacker.vorifice == "Cock Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to slide [affecting] into [M]'s cock!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[affecting] vanishes into [M]'s cock!</span>")
 					playsound(src, 'sound/vore/gulp.ogg', 100, 1)
+
 					affecting.loc = target
 					target.cock_contents.Add(affecting)
+
 					msg_admin_attack("[key_name(user)] forced [key_name(M)] to cock vore [key_name(affecting)]")
-					//del(src)
+
+					del(src)
+
+			//ANAL VORE
 				if(attacker.vorifice == "Anal Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to push [affecting] up [M]'s rear!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[affecting] disappears up [M]'s ass!</span>")
 					playsound(src, 'sound/vore/schlorp.ogg', 100, 1)
+
 					affecting.loc = target
 					target.stomach_contents.Add(affecting)
+
 					msg_admin_attack("[key_name(user)] forced [key_name(M)] to anal vore [key_name(affecting)]")
-					//del(src)
+
+					del(src)
+
+			//BREAST VORE
 				if(attacker.vorifice == "Breast Vore")
 					user.visible_message("<span class='danger'>[user] is attempting to stuff [affecting] into [M]'s breasts!</span>")
+
 					if(!istype(affecting,/mob/living/carbon/human))
 						if(!do_mob(user, affecting)||!do_after(user, 30)) return
 					else
 						if(!do_mob(user, affecting)||!do_after(user, 100)) return
+
 					user.visible_message("<span class='danger'>[M] sucks [affecting] into her tits!</span>")
 					playsound(src, 'sound/vore/insert.ogg', 100, 1)
+
 					affecting.loc = target
 					target.boob_contents.Add(affecting)
+
 					msg_admin_attack("[key_name(user)] forced [key_name(M)] to boob vore [key_name(affecting)]")
-					//del(src)
+
+					del(src)
 //End vore code.
 
 /obj/item/weapon/grab/dropped()

--- a/code/modules/vore/vore.dm
+++ b/code/modules/vore/vore.dm
@@ -5,53 +5,49 @@
 	set name = "Toggle Stomach Digestion"
 	set category = "Vore"
 
-	if(stendo == 0)
-		stendo = 1
-		src << "<span class='notice'>You will no longer digest people in your stomach.</span>"
-	else
-		stendo = 0
-		src << "<span class='notice'>You will now digest people in your stomach.</span>"
+	stendo = !stendo //invert
+	switch(stendo)
+		if(0)	src << "<span class='notice'>You will no longer digest people in your stomach.</span>"
+		if(1)	src << "<span class='notice'>You will now digest people in your stomach.</span>"
 
 /mob/living/carbon/human/proc/cvendo_toggle()
 	set name = "Toggle Cockvore Digestion"
 	set category = "Vore"
 
-	if(cvendo == 0)
-		cvendo = 1
-		src << "<span class='notice'>You will no longer cummify people.</span>"
-	else
-		cvendo = 0
-		src << "<span class='notice'>You will now cummify people.</span>"
+	cvendo = !cvendo
+	switch(cvendo)
+		if(0)	src << "<span class='notice'>You will no longer cummify people.</span>"
+		if(1)	src << "<span class='notice'>You will now cummify people.</span>"
 
 /mob/living/carbon/human/proc/bvendo_toggle()
 	set name = "Toggle Breastvore Digestion"
 	set category = "Vore"
 
-	if(bvendo == 0)
-		bvendo = 1
-		src << "<span class='notice'>You will no longer milkify people.</span>"
-	else
-		bvendo = 0
-		src << "<span class='notice'>You will now milkify people.</span>"
+	bvendo = !bvendo
+
+	switch(vendo)
+		if(0)	src << "<span class='notice'>You will no longer milkify people.</span>"
+		if(1)	src << "<span class='notice'>You will now milkify people.</span>"
 
 /mob/living/carbon/human/proc/womb_toggle()
 	set name = "Set Womb Mode"
 	set category = "Vore"
 	wombheal = input("Womb Mode") in list("Hold","Heal","Transform (Male)","Transform (Female)","Transform (Keep Gender)","Transform (Change Species)","Digest")
-	if(wombheal == "Heal")
-		src << "<span class='notice'>You will now heal people you've unbirthed.</span>"
-	if(wombheal == "Digest")
-		src << "<span class='notice'>You will now digest people you've unbirthed.</span>"
-	if(wombheal == "Hold")
-		src << "<span class='notice'>You will now harmlessly hold people you've unbirthed.</span>"
-	if(wombheal == "Transform (Male)")
-		src << "<span class='notice'>You will now transform people you've unbirthed into your son.</span>"
-	if(wombheal == "Transform (Female)")
-		src << "<span class='notice'>You will now transform people you've unbirthed into your daughter.</span>"
-	if(wombheal == "Transform (Keep Gender)")
-		src << "<span class='notice'>You will now transform people you've unbirthed, but they will keep their gender.</span>"
-	if(wombheal == "Transform (Change Species)")
-		src << "<span class='notice'>You will now transform people you've unbirthed to look similar to your species.</span>"
+	switch(wombheal)
+		if("Heal")
+			src << "<span class='notice'>You will now heal people you've unbirthed.</span>"
+		if("Digest")
+			src << "<span class='notice'>You will now digest people you've unbirthed.</span>"
+		if("Hold")
+			src << "<span class='notice'>You will now harmlessly hold people you've unbirthed.</span>"
+		if("Transform (Male)")
+			src << "<span class='notice'>You will now transform people you've unbirthed into your son.</span>"
+		if("Transform (Female)")
+			src << "<span class='notice'>You will now transform people you've unbirthed into your daughter.</span>"
+		if("Transform (Keep Gender)")
+			src << "<span class='notice'>You will now transform people you've unbirthed, but they will keep their gender.</span>"
+		if("Transform (Change Species)")
+			src << "<span class='notice'>You will now transform people you've unbirthed to look similar to your species.</span>"
 
 /mob/living/carbon/human/proc/orifice_toggle()
 	set name = "Choose Vore Mode"
@@ -66,113 +62,152 @@
 	set name = "Digestion Toggles"
 	set category = "Vore"
 	var/digestzone = input("Choose Organ") in list("Stomach","Cock","Breasts","Womb")
-	if(digestzone == "Stomach")
-		endo_toggle()
-		return
-	if(digestzone == "Cock")
-		cvendo_toggle()
-		return
-	if(digestzone == "Breasts")
-		bvendo_toggle()
-		return
-	if(digestzone == "Womb")
-		womb_toggle()
-		return
+
+	switch(digestzone)
+		if("Stomach")
+			endo_toggle()
+		if("Cock")
+			cvendo_toggle()
+		if("Breasts")
+			vendo_toggle()
+		if("Womb")
+			womb_toggle()
 
 
 /mob/living/carbon/human/proc/vore_release()
 	set name = "Release"
 	set category = "Vore"
 	var/releaseorifice = input("Choose Orifice") in list("Stomach (by Mouth)","Stomach (by Anus)","Womb","Cock","Breasts")
-	if(releaseorifice == "Stomach (by Mouth)")
-		if(stomach_contents.len)
-			for(var/mob/M in src)
-				if(M in stomach_contents)
+
+	switch(releaseorfice)
+		if("Stomach (by Mouth)")
+			if(stomach_contents.len)
+				for(var/mob/M in stomach_contents)
+
+					M.loc = src.loc //this is specifically defined as src.loc to try to prevent a mob from ending up in nullspace by byond confusion
 					stomach_contents.Remove(M)
-					for (var/mob/living/carbon/R in hearers(src.loc, null))
-						if(src in R.stomach_contents)
-							M.loc = R.stomach_contents
-						else
-							M.loc = loc
-				//Paralyse(10)
-			src.visible_message("\green <B>[src] hurls out the contents of their stomach!</B>")
-			playsound(loc, 'sound/effects/splat.ogg', 50, 1)
-		return
-	if(releaseorifice == "Stomach (by Anus)")
-		if(stomach_contents.len)
-			for(var/mob/M in src)
-				if(M in stomach_contents)
+
+					if(iscarbon(src.loc)) //This makes sure that the mob behaves properly if released into another mob
+						var/mob/living/carbon/loc_mob = src.loc
+
+						if(src in loc_mob.stomach_contents)
+							loc_mob.stomach_contents += M
+						if(src in loc_mob.womb_contents)
+							loc_mob.womb_contents += M
+						if(src in loc_mob.cock_contents)
+							loc_mob.cock_contents += M
+						if(src in loc_mob.boob_contents)
+							loc_mob.boob_contents += M
+
+				visible_message("<font color='green'><b>[src] hurls out the contents of their stomach!</b></font>")
+				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+
+		if("Stomach (by Anus)")
+			if(stomach_contents.len)
+				for(var/mob/M in stomach_contents)
+
+					M.loc = src.loc
 					stomach_contents.Remove(M)
-					for (var/mob/living/carbon/R in hearers(src.loc, null))
-						if(src in R.stomach_contents)
-							M.loc = R.stomach_contents
-						else
-							M.loc = loc
-					//Paralyse(10)
-			src.visible_message("\green <B>[src] releases their stomach contents out of their rear!</B>")
-			playsound(loc, 'sound/effects/splat.ogg', 50, 1)
-		return
-	if(releaseorifice == "Womb")
-		if(womb_contents.len)
-			for(var/mob/M in src)
-				if(M in womb_contents)
+
+					if(iscarbon(src.loc))
+						var/mob/living/carbon/loc_mob = src.loc
+
+						if(src in loc_mob.stomach_contents)
+							loc_mob.stomach_contents += M
+						if(src in loc_mob.womb_contents)
+							loc_mob.womb_contents += M
+						if(src in loc_mob.cock_contents)
+							loc_mob.cock_contents += M
+						if(src in loc_mob.boob_contents)
+							loc_mob.boob_contents += M
+
+				visible_message("<font color='green'><b>[src] releases their stomach contents out of their rear!</b></font>")
+				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+
+		if("Womb")
+			if(womb_contents.len)
+				for(var/mob/M in womb_contents)
+
+					M.loc = src.loc
 					womb_contents.Remove(M)
-					for (var/mob/living/carbon/R in hearers(src.loc, null))
-						if(src in R.womb_contents)
-							M.loc = R.womb_contents
-						else
-							M.loc = loc
-					//Paralyse(10)
-			src.visible_message("\green <B>[src] gushes out the contents of their womb!</B>")
-			playsound(loc, 'sound/effects/splat.ogg', 50, 1)
-		else
-			if(src.wombfull == 1)
-				wombfull = 0
-				src.visible_message("\red <B>[src] gushes out a puddle of liquid from their folds!</B>")
+
+					if(iscarbon(src.loc))
+						var/mob/living/carbon/loc_mob = src.loc
+
+						if(src in loc_mob.stomach_contents)
+							loc_mob.stomach_contents += M
+						if(src in loc_mob.womb_contents)
+							loc_mob.womb_contents += M
+						if(src in loc_mob.cock_contents)
+							loc_mob.cock_contents += M
+						if(src in loc_mob.boob_contents)
+							loc_mob.boob_contents += M
+
+				visible_message("<font color='green'><b>[src] gushes out the contents of their womb!</b></font>")
 				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 
-		return
-	if(releaseorifice == "Cock")
-		if(cock_contents.len)
-			for(var/mob/M in src)
-				if(M in cock_contents)
+			else
+				if(wombfull) //checks if true. If it's anything but 0, null, or "", it will set to 0.
+					wombfull = 0
+					visible_message("<span class='danger'>[src] gushes out a puddle of liquid from their folds!</span>")
+					playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+
+		if("Cock")
+			if(cock_contents.len)
+				for(var/mob/M in cock_contents)
+
+					M.loc = src.loc
 					cock_contents.Remove(M)
-					for (var/mob/living/carbon/R in hearers(src.loc, null))
-						if(src in R.cock_contents)
-							M.loc = R.cock_contents
-						else
-							M.loc = loc
-					//Paralyse(10)
-			src.visible_message("\green <B>[src] splurts out the contents of their cock!</B>")
-			playsound(loc, 'sound/effects/splat.ogg', 50, 1)
-		else
-			if(src.cockfull == 1)
-				cockfull = 0
-				src.visible_message("\red <B>[src] gushes out a puddle of cum from their cock!</B>")
+
+					if(iscarbon(src.loc))
+						var/mob/living/carbon/loc_mob = src.loc
+
+						if(src in loc_mob.stomach_contents)
+							loc_mob.stomach_contents += M
+						if(src in loc_mob.womb_contents)
+							loc_mob.womb_contents += M
+						if(src in loc_mob.cock_contents)
+							loc_mob.cock_contents += M
+						if(src in loc_mob.boob_contents)
+							loc_mob.boob_contents += M
+
+				visible_message("<font color='green'><b>[src] splurts out the contents of their cock!</b></font>")
 				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 
-		return
+			else
+				if(cockfull)
+					cockfull = 0
+					visible_message("<span class='danger'>[src] gushes out a puddle of cum from their cock!</span>")
+					playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 
-	if(releaseorifice == "Breasts")
-		if(boob_contents.len)
-			for(var/mob/M in src)
-				if(M in boob_contents)
+		if("Breasts")
+			if(boob_contents.len)
+				for(var/mob/M in boob_contents)
+
+					M.loc = src.loc
 					boob_contents.Remove(M)
-					for (var/mob/living/carbon/R in hearers(src.loc, null))
-						if(src in R.boob_contents)
-							M.loc = R.boob_contents
-						else
-							M.loc = loc
-					//Paralyse(10)
-				src.visible_message("\green <B>[src] squirts out the contents of their breasts!</B>")
-				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
-		else
-			if(src.boobfull == 1)
-				boobfull = 0
-				src.visible_message("\red <B>[src] squirts out a puddle of milk from their breasts!</B>")
+
+					if(iscarbon(src.loc))
+						var/mob/living/carbon/loc_mob = src.loc
+
+						if(src in loc_mob.stomach_contents)
+							loc_mob.stomach_contents += M
+						if(src in loc_mob.womb_contents)
+							loc_mob.womb_contents += M
+						if(src in loc_mob.cock_contents)
+							loc_mob.cock_contents += M
+						if(src in loc_mob.boob_contents)
+							loc_mob.boob_contents += M
+
+				visible_message("<font color='green'><b>[src] squirts out the contents of their breasts!</b></font>")
 				playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 
-		return
+			else
+				if(boobfull)
+					boobfull = 0
+					visible_message("<span class='danger'>[src] squirts out a puddle of milk from their breasts!</span>")
+					playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+
 
 /////////////////////////////
 //// NW's emergency code ////
@@ -181,13 +216,18 @@
 /mob/living/proc/escapeOOC()
 	set name = "OOC escape"
 	set category = "Vore"
-	if(alert(src,"This button is for escaping from your partner if they have disconnected or your preferences are being violated. Do not use it for anything else!","","Okay","cancel") == "Okay")
-		if(istype(src.loc,/mob/living/carbon)||istype(src.loc,/mob/living/simple_animal))
-			msg_admin_attack("[key_name(usr)] used the OOC escape button to get out of [src.loc]")
+
+	var/confirm = alert(src, "This button is for escaping from your partner if they have disconnected or your preferences are being violated. Do not use it for anything else!", "Confirmation", "Okay", "Cancel")
+
+	if(confirm == "Cancel")	return
+
+	else if(confirm == "Okay")
+		if(iscarbon(loc) || isanimal(loc))
+			msg_admin_attack("[key_name(src)] used the OOC escape button to get out of [loc]")
 			src.loc = get_turf(src.loc)
 
 		else
-			src.visible_message("\red You aren't inside anyone, you clod.")
+			src << "<span class='alert'>You aren't inside anyone, you clod.</span>"
 
 /////////////////////////
 /// NW's Inside Panel ///
@@ -266,19 +306,19 @@
 	if(href_list["helpout"])
 		var/mob/living/subj=locate(href_list["helpout"])
 		var/mob/living/eater = usr.loc
-		usr << "\green You begin to push [subj] to freedom!"
+		usr << "<font color='green'>You begin to push [subj] to freedom!</font>"
 		subj << "[usr] begins to push you to freedom!"
-		eater << "\red Someone is trying to escape from inside you!"
+		eater << "<span class='warning'>Someone is trying to escape from inside you!<span>"
 		sleep(50)
 		if(prob(33))
 			subj.loc = eater.loc
-			usr << "\green You manage to help [subj] to safety!"
-			subj << "\green [usr] pushes you free!"
-			eater << "\red [subj] forces free of the confines of your body!"
+			usr << "<font color='green'>You manage to help [subj] to safety!</font>"
+			subj << "<font color='green'>[usr] pushes you free!</font>"
+			eater << "<span class='alert'>[subj] forces free of the confines of your body!</span>"
 		else
-			usr << "\red [subj] slips back down inside despite your efforts."
-			subj << "\red Even with [usr]'s help, you slip back inside again."
-			eater << "\green Your body efficiently shoves [subj] back where they belong."
+			usr << "<span class='alert'>[subj] slips back down inside despite your efforts.</span>"
+			subj << "<span class='alert'> Even with [usr]'s help, you slip back inside again.</span>"
+			eater << "<font color='green'>Your body efficiently shoves [subj] back where they belong.</font>"
 
 	if(href_list["set_description_belly"])
 		var/mob/living/carbon/human/M = usr
@@ -296,12 +336,12 @@
 		var/mob/living/carbon/human/M = usr
 		M.insideflavour[4] = input(M, "Input a few flavour text!", "Breasts flavour text", M.insideflavour[4])
 
-mob/living/carbon/human/proc/I_am_not_mad()
+/mob/living/carbon/human/proc/I_am_not_mad()
 	set name = "Toggle digestability"
 	set category = "Vore"
 
 	if(alert(src, "This button is for those who don't like being digested. It will make you undigestable. Don't abuse this button by toggling it back and forth to extend a scene or whatever, or you'll make the admins cry. Note that this cannot be toggled inside someone's belly.", "", "Okay", "Cancel") == "Okay")
-		src.digestable = !src.digestable
-		if(src.digestable == 1) usr << "\red You are now digestable."
-		else usr << "\red You are now undigestable."
-		msg_admin_attack("[key_name(usr)] toggled their digestability to [src.digestable]")
+		digestable = !digestable
+		if(src.digestable == 1) usr << "<span class='alert'>You are now digestable.</span>"
+		else usr << "<span class='alert'>You are now undigestable.</span>"
+		msg_admin_attack("[key_name(src)] toggled their digestability to [digestable]")

--- a/code/modules/vore/vore.dm
+++ b/code/modules/vore/vore.dm
@@ -25,7 +25,7 @@
 
 	bvendo = !bvendo
 
-	switch(vendo)
+	switch(bvendo)
 		if(0)	src << "<span class='notice'>You will no longer milkify people.</span>"
 		if(1)	src << "<span class='notice'>You will now milkify people.</span>"
 
@@ -69,7 +69,7 @@
 		if("Cock")
 			cvendo_toggle()
 		if("Breasts")
-			vendo_toggle()
+			bvendo_toggle()
 		if("Womb")
 			womb_toggle()
 
@@ -79,7 +79,7 @@
 	set category = "Vore"
 	var/releaseorifice = input("Choose Orifice") in list("Stomach (by Mouth)","Stomach (by Anus)","Womb","Cock","Breasts")
 
-	switch(releaseorfice)
+	switch(releaseorifice)
 		if("Stomach (by Mouth)")
 			if(stomach_contents.len)
 				for(var/mob/M in stomach_contents)


### PR DESCRIPTION
This PR cleans up some of the old code ported by PR #2.

Systems refactored:
 - Most of vore.dm
  - Most notable changes are to the release verb, which should function properly now when a mob releases another mob inside a mob.
 - Carbon relaymove
  - 2 second delay between messages _actually works now_
 - vomit() and the release verb should properly function now, adding people to the right lists if they are released inside another mob.
 - Inside panel 

Systems cleaned and prettied up:
 - Holder afterattack code, cleaned up with spaces and table-of-contents-esq comments.
  - Also, a note, preattack isn't a thing. afterattack is the correct thing to override.
 - Grab-eating, cleaned with spaces and table-of-contents-esq comments.
 - handle_x() Life() procs separated and spaced out a bit, table-of-contents-esq comments added

Fixes:
 - Added quick-fix for mob's suffocating inside other mobs, it appears to have been overlooked by 2.
 - ~~The digestion preferences were backwards, the verb to change them claimed they were off when they were turned on.~~
  - Actually, I read it backwards. However, they are completely inverted now, so it functions properly.