### PR TITLE
Master

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -159,6 +159,9 @@
 	var/use_lib_nudge = 0 //Use the C library nudge instead of the python nudge.
 	var/use_overmap = 0
 
+	var/jchat_url = ""	// Url to the JChat installation to send announcements to. ex: http://chat.blah.com/jchat
+	var/jchat_api_key = ""  // The API key configured in JChat's settings
+
 	var/list/station_levels = list(1)				// Defines which Z-levels the station exists on.
 	var/list/admin_levels= list(2)					// Defines which Z-levels which are for admin functionality, for example including such areas as Central Command and the Syndicate Shuttle
 	var/list/contact_levels = list(1, 5)			// Defines which Z-levels which, for example, a Code Red announcement may affect
@@ -478,6 +481,12 @@
 
 				if("use_irc_bot")
 					use_irc_bot = 1
+
+				if ("jchat_url")
+					jchat_url = trim(value)
+
+				if ("jchat_api_key")
+					jchat_api_key = trim(value)
 
 				if("ticklag")
 					Ticklag = text2num(value)

--- a/code/defines/procs/announce.dm
+++ b/code/defines/procs/announce.dm
@@ -53,6 +53,16 @@ datum/announcement/proc/Message(message as text, message_title as text)
 			if (announcer)
 				M << "<span class='alert'> -[html_encode(announcer)]</span>"
 
+datum/announcement/proc/NotifyChat(message as text, message_title as text)
+	if (config.jchat_url)
+		spawn(0)
+			var/query_string = "action=announceAllRooms"
+			query_string += "&key=[url_encode(config.jchat_api_key)]"
+			query_string += "&message=[url_encode(message)]"
+			query_string += "&title=[url_encode(message_title)]"
+			query_string += "&announcer=[url_encode(announcer)]"
+			world.Export("[config.jchat_url]/voreStationApi.srv?[query_string]")
+
 datum/announcement/minor/Message(message as text, message_title as text)
 	world << "<b>[message]</b>"
 
@@ -62,6 +72,7 @@ datum/announcement/priority/Message(message as text, message_title as text)
 	if(announcer)
 		world << "<span class='alert'> -[html_encode(announcer)]</span>"
 	world << "<br>"
+	NotifyChat(message, message_title)
 
 datum/announcement/priority/command/Message(message as text, message_title as text)
 	var/command

--- a/code/defines/procs/dbcore.dm
+++ b/code/defines/procs/dbcore.dm
@@ -72,7 +72,12 @@ DBConnection/proc/IsConnected()
 
 DBConnection/proc/Quote(str) return _dm_db_quote(_db_con,str)
 
-DBConnection/proc/ErrorMsg() return _dm_db_error_msg(_db_con)
+DBConnection/proc/ErrorMsg()
+	if (!sqllogging)
+		return "SQL Connection disabled by configuration.  Set ENABLE_STAT_TRACKING to enable"
+	else
+		return _dm_db_error_msg(_db_con)
+
 DBConnection/proc/SelectDB(database_name,dbi)
 	if(IsConnected()) Disconnect()
 	//return Connect("[dbi?"[dbi]":"dbi:mysql:[database_name]:[DB_SERVER]:[DB_PORT]"]",user,password)


### PR DESCRIPTION
What it says on the tin.  
After merging this, jchat integration is off by default, but is enabled by adding the url and passkey to the configuration file.