### PR TITLE
Fixes

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -17,6 +17,7 @@
 	circuit = "/obj/item/weapon/circuitboard/cryopodcontrol"
 	density = 0
 	interact_offline = 1
+	req_one_access = list(access_heads, access_armory)
 	var/mode = null
 
 	//Used for logging people entering cryosleep and important items they are carrying.
@@ -93,6 +94,9 @@
 		user << browse(dat, "window=cryoitems")
 
 	else if(href_list["item"])
+		if(!allowed(user))
+			user << "<span class='warning'>Access Denied.</span>"
+			return
 		if(!allow_items) return
 
 		if(frozen_items.len == 0)
@@ -113,6 +117,9 @@
 		frozen_items -= I
 
 	else if(href_list["allitems"])
+		if(!allowed(user))
+			user << "<span class='warning'>Access Denied.</span>"
+			return
 		if(!allow_items) return
 
 		if(frozen_items.len == 0)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -620,6 +620,8 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	return 1
 
 mob/dead/observer/MayRespawn(var/feedback = 0)
+	if(started_as_observer && client)
+		return 1
 	if(!client || !mind)
 		return 0
 	if(mind.current && mind.current.stat != DEAD)


### PR DESCRIPTION
Fixes #45 
Fixes #30 

To dispense cryodorm items, you now need access_heads or access_armory.
Observers are automatically eligable for MayRespawn() checks; Used for everything from ERT's to Drones.