### PR TITLE
Atmos Machinery Enhancement

### DIFF
--- a/code/game/machinery/atmoalter/meter.dm
+++ b/code/game/machinery/atmoalter/meter.dm
@@ -68,7 +68,7 @@
 /obj/machinery/meter/examine(mob/user)
 	var/t = "A gas flow meter. "
 	
-	if(get_dist(user, src) > 3 && !(istype(user, /mob/living/silicon/ai) || istype(user, /mob/dead)))
+	if(get_dist(user, src) > 5 && !(istype(user, /mob/living/silicon/ai) || istype(user, /mob/dead)))
 		t += "\blue <B>You are too far away to read it.</B>"
 	
 	else if(stat & (NOPOWER|BROKEN))
@@ -87,7 +87,7 @@
 
 /obj/machinery/meter/Click()
 
-	if(istype(usr, /mob/living/silicon/ai)) // ghosts can call ..() for examine
+	if(istype(usr, /mob/living/carbon/human) || istype(usr, /mob/living/silicon/ai)) // ghosts can call ..() for examine
 		usr.examinate(src)
 		return 1
 	

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -103,7 +103,7 @@
 	// Let default implementation determine if user can use it or not
 	if (..())
 		usr << browse(null, "window=scrubber")
-		return 1;
+		return 1
 	user.set_machine(src)
 	var/holding_text
 
@@ -143,7 +143,7 @@ Flow Rate Regulator: <A href='?src=\ref[src];volume_adj=-1000'>-</A> <A href='?s
 	// Delegate checks to parent method, which calls CanUseTopic().  If success, parent automatically sets machine too.
 	if (..())
 		usr << browse(null, "window=scrubber")
-		return 1;
+		return 1
 	else
 		if(href_list["power"])
 			on = !on

--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -196,7 +196,7 @@ Class Procs:
 	user.set_machine(src)
 
 /obj/machinery/CouldNotUseTopic(var/mob/user)
-	usr.unset_machine()
+	user.unset_machine()
 
 ////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -214,10 +214,10 @@ Class Procs:
 		return 1
 	if(user.lying || user.stat)
 		return 1
-	if ( ! (istype(usr, /mob/living/carbon/human) || \
-			istype(usr, /mob/living/silicon) || \
-			istype(usr, /mob/living/carbon/monkey)) )
-		usr << "\red You don't have the dexterity to do this!"
+	if ( ! (istype(user, /mob/living/carbon/human) || \
+			istype(user, /mob/living/silicon) || \
+			istype(user, /mob/living/carbon/monkey)) )
+		user << "\red You don't have the dexterity to do this!"
 		return 1
 /*
 	//distance checks are made by atom/proc/DblClick


### PR DESCRIPTION
:white_check_mark: **New Features**
* Portable Scrubber Dialog now allows configuring which gases the unit scrubs!
 * To reduce greifing this function is locked, requires atmos ID to
unlock.

:wrench:  **Fixes**
* System Wide:
 * Fixed "usr" vs "user" typos in /obj/machinery
* To  Portable Scrubber:
 * Fixed  names to not be proper nouns (so 'the' is not omitted)
 * Changed the panel to use the NT UI theme
 * Enhanced the user of super-type calls to take advantage of shared code
in /obj/machinery - results in less code duplication and better support
for when you can/can't use machines.
* To Gas Meters
 * Gas meters can once again be read just by clicking on them. (#53)