### PR TITLE
Issue 50: Fix PDA Button Backgrounds

### DIFF
--- a/nano/js/nano_base_helpers.js
+++ b/nano/js/nano_base_helpers.js
@@ -28,7 +28,7 @@ NanoBaseHelpers = function ()
 
 				if (typeof elementClass == 'undefined' || !elementClass)
 				{
-					elementClass = 'link';
+					elementClass = '';
 				}
 
 				var elementIdHtml = '';
@@ -42,7 +42,7 @@ NanoBaseHelpers = function ()
 					return '<div unselectable="on" class="link ' + iconClass + ' ' + elementClass + ' ' + status + '" ' + elementIdHtml + '>' + iconHtml + text + '</div>';
 				}
 
-				return '<div unselectable="on" class="linkActive ' + iconClass + ' ' + elementClass + '" data-href="' + NanoUtility.generateHref(parameters) + '" ' + elementIdHtml + '>' + iconHtml + text + '</div>';
+				return '<div unselectable="on" class="link linkActive ' + iconClass + ' ' + elementClass + '" data-href="' + NanoUtility.generateHref(parameters) + '" ' + elementIdHtml + '>' + iconHtml + text + '</div>';
 			},
 			// Round a number to the nearest integer
 			round: function(number) {


### PR DESCRIPTION
:wrench: Fixes
* Fixed PDA Buttons to actually look like a button with blue background.  ( #50 )
 * In the javascript function which handles button links in nanoui
templates, if the elementClass parameter (which allows specifying a
custom css class for this link) was passed then the link HTML was being
generated *without* the "link" class.    The link class is what makes it
look properly like a button.