### PR TITLE
Phoron Glass

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -176,7 +176,6 @@
 	created_window = /obj/structure/window/phoronbasic
 
 /obj/item/stack/sheet/glass/phoronglass/attackby(obj/item/W, mob/user)
-	..()
 	if( istype(W, /obj/item/stack/rods) )
 		var/obj/item/stack/rods/V  = W
 		var/obj/item/stack/sheet/glass/phoronrglass/RG = new (user.loc)

--- a/code/modules/mining/alloys.dm
+++ b/code/modules/mining/alloys.dm
@@ -25,3 +25,12 @@
 		"hematite" = 1
 		)
 	product = /obj/item/stack/sheet/metal
+
+/datum/alloy/phoronglass
+	metaltag = "phoronglass"
+	requires = list(
+		"phoron" = 1,
+		"sand" = 2
+		)
+	product_mod = 0.3  //  produce ~one phoronglass out per phoron in.
+	product = /obj/item/stack/sheet/glass/phoronglass

--- a/code/modules/mining/machine_stacking.dm
+++ b/code/modules/mining/machine_stacking.dm
@@ -93,6 +93,8 @@
 	stack_paths["metal"] = /obj/item/stack/sheet/metal
 	stack_storage["plasteel"] = 0
 	stack_paths["plasteel"] = /obj/item/stack/sheet/plasteel
+	stack_storage["phoron glass"] = 0
+	stack_paths["phoron glass"] = /obj/item/stack/sheet/glass/phoronglass
 
 	spawn( 5 )
 		for (var/dir in cardinal)

--- a/code/modules/mining/ore_datum.dm
+++ b/code/modules/mining/ore_datum.dm
@@ -21,11 +21,13 @@
 /datum/ore/glass
 	smelts_to = /obj/item/stack/sheet/glass
 	compresses_to = /obj/item/stack/sheet/mineral/sandstone
+	alloy = 1
 	oretag = "sand"
 
 /datum/ore/phoron
 	//smelts_to = something that explodes violently on the conveyor, huhuhuhu
 	compresses_to = /obj/item/stack/sheet/mineral/phoron
+	alloy = 1
 	oretag = "phoron"
 
 /datum/ore/silver


### PR DESCRIPTION
Currently there is no way to make phoron glass.
Regular glass comes from sand, so I figure mixing 2x sand + 1x phoron ore should give 1x
phoron glass.   
* Added that formula to alloy datums so it can be made at the mining base.
* Also made the stacking machine recognize it can stack phoron glass.
* Fixed a bug where creation of reinforced phoron glass would also create regular reinforced glass.