### PR TITLE
Asteroid Mineral Distribution Overhaul

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -384,6 +384,44 @@
 	mineralSpawnChanceList = list("Uranium" = 10, "Platinum" = 10, "Iron" = 20, "Coal" = 20, "Diamond" = 2, "Gold" = 10, "Silver" = 10, "Phoron" = 20)
 
 
+/**********************MapGen**************************/
+
+/turf/simulated/mineral/specific
+	var/mineral_name = ""
+
+/turf/simulated/mineral/specific/New()
+	if (!name_to_mineral)
+		SetupMinerals() // Make sure the map of singletons is initialized
+	if (mineral_name && mineral_name in name_to_mineral)
+		mineral = name_to_mineral[mineral_name]
+		UpdateMineral()
+	. = ..()
+
+// Declare one for each type of mineral
+/turf/simulated/mineral/specific/uranium
+	mineral_name = "Uranium"
+
+/turf/simulated/mineral/specific/platinum
+	mineral_name = "Platinum"
+
+/turf/simulated/mineral/specific/iron
+	mineral_name = "Iron"
+
+/turf/simulated/mineral/specific/coal
+	mineral_name = "Coal"
+
+/turf/simulated/mineral/specific/diamond
+	mineral_name = "Diamond"
+
+/turf/simulated/mineral/specific/gold
+	mineral_name = "Gold"
+
+/turf/simulated/mineral/specific/silver
+	mineral_name = "Silver"
+
+/turf/simulated/mineral/specific/phoron
+	mineral_name = "Phoron"
+
 /**********************Asteroid**************************/
 
 


### PR DESCRIPTION
Minerals on the asteroid consist of the underground resources and the actual turf itself.  The distribution of surface turf minerals resulted in very low amounts.
Part of this is because it distributes it randomly throughout the designated asteroid area, without actually checking if the tile it plans to put minerals on is actually designated in the map as randomizable (masked).   When it comes time to actually place the minerals, non-masked tiles are skipped, so you end up with less minerals than planned.  This can be solved by simply checking.

The second issue is that the map generator decides to place a bunch of mineral turfs, but the turf itself then randomly picks what type.   This does not happen until its instantiated; too late to efficiently try and reroll. Instead we have pre-defined numbers of tiles that will be seeded with minerals.

I figure that it doesn't hurt gameplay to have a (semi-)fixed amount of each mineral as long as you don't know WHERE they will be distributed!  In fact it helps us better ensure balance.
One caveat is that even if we seed exactly 100 iron turfs, the MineralSpread() proc has a good chance of growing the vein, so its still partly random.

The number of seeded turfs for each mineral probably will need tuning.  Luckily that's nice and easy up at the top.  In order to help with that, it also prints the exact actual number of tiles with each mineral to the world log.


