### PR TITLE
Supermatter Powers Radiation Collectors

### DIFF
--- a/code/game/turfs/simulated/walls_mineral.dm
+++ b/code/game/turfs/simulated/walls_mineral.dm
@@ -52,6 +52,10 @@
 				L.apply_effect(12,IRRADIATE,0)
 			for(var/turf/simulated/wall/mineral/uranium/T in range(3,src))
 				T.radiate()
+			for(var/obj/machinery/power/rad_collector/R in rad_collectors)
+				var/distance = get_dist(R, src)
+				if(distance <= 3)
+					R.receive_pulse(120)
 			last_event = world.time
 			active = null
 			return
@@ -67,6 +71,11 @@
 
 /turf/simulated/wall/mineral/uranium/Bumped(AM as mob|obj)
 	radiate()
+	..()
+
+/turf/simulated/wall/mineral/uranium/bullet_act(var/obj/item/projectile/Proj)
+	if(istype(Proj, /obj/item/projectile/beam/emitter))
+		radiate()
 	..()
 
 /turf/simulated/wall/mineral/phoron

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -209,7 +209,7 @@
 		power = max( (removed.temperature * temp_factor) * oxygen + power, 0)
 
 		//We've generated power, now let's transfer it to the collectors for storing/usage
-		//transfer_energy()
+		transfer_energy()
 
 		var/device_energy = power * REACTION_POWER_MODIFIER
 
@@ -273,7 +273,7 @@
 
 	Consume(user)
 
-/*
+
 /obj/machinery/power/supermatter/proc/transfer_energy()
 	for(var/obj/machinery/power/rad_collector/R in rad_collectors)
 		var/distance = get_dist(R, src)
@@ -281,7 +281,7 @@
 			//for collectors using standard phoron tanks at 1013 kPa, the actual power generated will be this power*POWER_FACTOR*20*29 = power*POWER_FACTOR*580
 			R.receive_pulse(power * POWER_FACTOR * (min(3/distance, 1))**2)
 	return
-*/
+
 
 /obj/machinery/power/supermatter/attackby(obj/item/weapon/W as obj, mob/living/user as mob)
 	user.visible_message("<span class=\"warning\">\The [user] touches \a [W] to \the [src] as a silence fills the room...</span>",\


### PR DESCRIPTION
* Baycode turned off radiation collectors working with supermatter.
Restored it!
* Hey, Uranium walls irradiate people, lets make them work with
radiation collectors too!  Also they should radiate when hit with
emitters, for superfun.