### PR TITLE
Fixed Loyalty Implants

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -129,7 +129,7 @@ datum/mind
 		if (istype(current, /mob/living/carbon/human) || istype(current, /mob/living/carbon/monkey))
 			/** Impanted**/
 			if(istype(current, /mob/living/carbon/human))
-				if(H.is_loyalty_implanted(H))
+				if(H.is_loyalty_implanted())
 					text = "Loyalty Implant:<a href='?src=\ref[src];implant=remove'>Remove</a>|<b>Implanted</b></br>"
 				else
 					text = "Loyalty Implant:<b>No Implant</b>|<a href='?src=\ref[src];implant=add'>Implant him!</a></br>"
@@ -141,7 +141,7 @@ datum/mind
 			if (ticker.mode.config_tag=="revolution")
 				text += uppertext(text)
 			text = "<i><b>[text]</b></i>: "
-			if (istype(current, /mob/living/carbon/monkey) || H.is_loyalty_implanted(H))
+			if (istype(current, /mob/living/carbon/monkey) || H.is_loyalty_implanted())
 				text += "<b>LOYAL EMPLOYEE</b>|headrev|rev"
 			else if (src in ticker.mode.head_revolutionaries)
 				text = "<a href='?src=\ref[src];revolution=clear'>employee</a>|<b>HEADREV</b>|<a href='?src=\ref[src];revolution=rev'>rev</a>"
@@ -171,7 +171,7 @@ datum/mind
 			if (ticker.mode.config_tag=="cult")
 				text = uppertext(text)
 			text = "<i><b>[text]</b></i>: "
-			if (istype(current, /mob/living/carbon/monkey) || H.is_loyalty_implanted(H))
+			if (istype(current, /mob/living/carbon/monkey) || H.is_loyalty_implanted())
 				text += "<B>LOYAL EMPLOYEE</B>|cultist"
 			else if (src in ticker.mode.cult)
 				text += "<a href='?src=\ref[src];cult=clear'>employee</a>|<b>CULTIST</b>"
@@ -241,7 +241,7 @@ datum/mind
 			text = uppertext(text)
 		text = "<i><b>[text]</b></i>: "
 		if(istype(current, /mob/living/carbon/human))
-			if (H.is_loyalty_implanted(H))
+			if (H.is_loyalty_implanted())
 				text +="traitor|<b>LOYAL EMPLOYEE</b>"
 			else
 				if (src in ticker.mode.traitors)
@@ -512,7 +512,7 @@ datum/mind
 					H << "\blue <Font size =3><B>Your loyalty implant has been deactivated.</B></FONT>"
 
 				if("add")
-					H.implant_loyalty(H, override = TRUE)
+					H.implant_loyalty(override = TRUE)
 					H << "\red <Font size =3><B>You somehow have become the recepient of a loyalty transplant, and it just activated!</B></FONT>"
 					if(src in ticker.mode.revolutionaries)
 						special_role = null

--- a/code/game/jobs/job/captain.dm
+++ b/code/game/jobs/job/captain.dm
@@ -38,7 +38,7 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 		var/sound/announce_sound = (ticker.current_state <= GAME_STATE_SETTING_UP)? null : sound('sound/misc/boatswain.ogg', volume=20)
 		captain_announcement.Announce("All hands, Captain [H.real_name] on deck!", new_sound=announce_sound)
 
-		H.implant_loyalty(src)
+		H.implant_loyalty()
 
 		return 1
 
@@ -93,4 +93,4 @@ var/datum/announcement/minor/captain_announcement = new(do_newscast = 1)
 		var/sound/announce_sound = (ticker.current_state <= GAME_STATE_SETTING_UP)? null : sound('sound/misc/boatswain.ogg', volume=20)
 		captain_announcement.Announce("All hands, [H.real_name] is the Head of Personnel!", new_sound=announce_sound)
 
-		H.implant_loyalty(src)
+		H.implant_loyalty()

--- a/code/game/jobs/job/civilian.dm
+++ b/code/game/jobs/job/civilian.dm
@@ -362,7 +362,7 @@
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 
-		H.implant_loyalty(H)
+		H.implant_loyalty()
 
 
 		return 1

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -39,7 +39,7 @@
 		else
 			H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
 			H.equip_to_slot_or_del(new /obj/item/weapon/handcuffs(H), slot_in_backpack)
-		H.implant_loyalty(H)
+		H.implant_loyalty()
 		return 1
 
 

--- a/code/modules/admin/verbs/striketeam.dm
+++ b/code/modules/admin/verbs/striketeam.dm
@@ -158,7 +158,7 @@ var/global/sent_strike_team = 0
 	equip_to_slot_or_del(new /obj/item/weapon/gun/energy/pulse_rifle(src), slot_r_hand)
 
 
-	implant_loyalty(src)
+	implant_loyalty()
 
 
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -205,20 +205,20 @@
 		updatehealth()
 	return
 
-/mob/living/carbon/human/proc/implant_loyalty(mob/living/carbon/human/M, override = FALSE) // Won't override by default.
+/mob/living/carbon/human/proc/implant_loyalty(override = FALSE) // Won't override by default.
 	if(!config.use_loyalty_implants && !override) return // Nuh-uh.
 
-	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(M)
-	L.imp_in = M
+	var/obj/item/weapon/implant/loyalty/L = new/obj/item/weapon/implant/loyalty(src)
+	L.imp_in = src
 	L.implanted = 1
-	var/datum/organ/external/affected = M.organs_by_name["head"]
+	var/datum/organ/external/affected = organs_by_name["head"]
 	affected.implants += L
 	L.part = affected
 
 /mob/living/carbon/human/proc/is_loyalty_implanted(mob/living/carbon/human/M)
-	for(var/L in M.contents)
+	for(var/L in src.contents)
 		if(istype(L, /obj/item/weapon/implant/loyalty))
-			for(var/datum/organ/external/O in M.organs)
+			for(var/datum/organ/external/O in src.organs)
 				if(L in O.implants)
 					return 1
 	return 0

--- a/config/example/game_options.txt
+++ b/config/example/game_options.txt
@@ -63,4 +63,4 @@ ANIMAL_DELAY 0
 ## Config options which, of course, don't fit into previous categories.
 
 ## Remove the # in front of this config option to have loyalty implants spawn by default on your server.
-#USE_LOYALTY_IMPLANTS
+USE_LOYALTY_IMPLANTS


### PR DESCRIPTION
This is a fix to issue #101 
* Attempting to enable loyalty implants in config caused runtime errors
on join; this is because the job definitions were incorrectly calling
the implant_loyalty() proc.
* The implant_loyalty proc was stupid.  It was defined on
mob/living/carbon/human, but didn't act on its 'src', you had to pass it
another carbon/human as a parameter.  This makes no sense whatsoever.  I
just fixed it to be sane.
* is_loyalty_implanted() proc had the same issue.