### PR TITLE
Pepperspray noise and CC Fax Reply

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1529,7 +1529,7 @@
 		var/mob/sender = locate(href_list["CentComFaxReply"])
 		var/obj/machinery/photocopier/faxmachine/fax = locate(href_list["originfax"])
 
-		var/input = input(src.owner, "Please enter a message to reply to [key_name(sender)] via secure connection. NOTE: BBCode does not work, but HTML tags do! Use <br> for line breaks.", "Outgoing message from CentCom", "") as message|null
+		var/input = input(src.owner, "Please enter a message to reply to [key_name(sender)] via secure connection. NOTE: BBCode works here, but HTML does not.", "Outgoing message from CentCom", "") as message|null
 		if(!input)	return
 
 		var/customname = input(src.owner, "Pick a title for the report", "Title") as text|null
@@ -1538,6 +1538,9 @@
 		var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( null ) //hopefully the null loc won't cause trouble for us
 		P.name = "[command_name()]- [customname]"
 		P.info = input
+		P.info = html_encode(P.info)
+		P.info = replacetext(P.info, "\n", "<BR>")
+		P.info = P.parsepencode(P.info)
 		P.update_icon()
 
 		// Stamps

--- a/code/modules/reagents/reagent_containers/spray.dm
+++ b/code/modules/reagents/reagent_containers/spray.dm
@@ -46,7 +46,8 @@
 		user << "<span class='notice'>\The [src] is empty!</span>"
 		return
 
-	Spray_at(A, user, proximity)
+	if (Spray_at(A, user, proximity))
+		return // Do not play sound or alert if we did not spray
 
 	playsound(src.loc, 'sound/effects/spray2.ogg', 50, 1, -6)
 
@@ -61,6 +62,7 @@
 		log_game("[key_name(user)] fired Space lube from \a [src].")
 	return
 
+/* Returns 0 if successful, -1 if failed to spray */
 /obj/item/weapon/reagent_containers/spray/proc/Spray_at(atom/A as mob|obj, mob/user as mob, proximity)
 	if (A.density && proximity)
 		A.visible_message("[usr] sprays [A] with [src].")
@@ -160,10 +162,11 @@
 	safety = !safety
 	usr << "<span class = 'notice'>You switch the safety [safety ? "on" : "off"].</span>"
 
+/* Returns 0 if sprayed, -1 if failed to spray */
 /obj/item/weapon/reagent_containers/spray/pepper/Spray_at(atom/A as mob|obj)
 	if(safety)
 		usr << "<span class = 'warning'>The safety is on!</span>"
-		return
+		return -1
 	..()
 
 //water flower


### PR DESCRIPTION
* Fixed pepperspray to not make noise nor alert admins if it does not
actually spray due to safety being on. (Issue #130) 
* Change CentCom fax replies to use BBCode in order to be consistent with
other faxes. (Issue #114 )