### PR TITLE
Fixed DNA Editor

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -60,7 +60,7 @@
 		power -= 4
 
 	// Append zeroes to make sure that hex is atleast digits long.
-	var/left = length(hex) - digits
+	var/left = digits - length(hex)
 	while (left-- > 0)
 		hex = text("0[]", hex)
 

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -322,7 +322,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 
 
 /proc/EncodeDNABlock(var/value)
-	return add_zero2(num2hex(value,1), 3)
+	return num2hex(value, 3)
 
 /datum/dna/proc/UpdateUI()
 	src.uni_identity=""


### PR DESCRIPTION
* The proc num2hex was incorrectly padding on extra zeros.  Instead of
padding to a given length if the hex was too short, it would pad more
the longer the hex was!  Result of transposed variables in subtraction.
* At the same time, given that num2hex already pads to 3 digits, there
is no reason whatsoever to call add_zero2() in dna processing.
* Fixes Issue #131 