### PR TITLE
Increase Job Cap on Security

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -128,7 +128,7 @@
 	flag = OFFICER
 	department_flag = ENGSEC
 	faction = "Station"
-	total_positions = 3
+	total_positions = 5
 	spawn_positions = 3
 	supervisors = "the head of security"
 	selection_color = "#ffeeee"


### PR DESCRIPTION
Fixed #175 - Increased total job cap for security to 5 now that we do
not have blue shield.
I left spawn cap to 3 to avoid unintentional flooding on server start;
this can always be changed if inconvenient.