### PR TITLE
Night micros

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -495,12 +495,117 @@
 			if((tmob.a_intent == "help" || tmob.restrained()) && (a_intent == "help" || src.restrained()) && tmob.canmove && !tmob.buckled && canmove) // mutual brohugs all around!
 				var/turf/oldloc = loc
 				loc = tmob.loc
+				if(src.playerscale <= RESIZE_A_SMALLTINY && tmob.playerscale <= RESIZE_A_SMALLTINY)
+					now_pushing = 0
+					return
+				if(abs(src.playerscale - tmob.playerscale) >= 0.75)
+					now_pushing = 0
+					if(src.playerscale > tmob.playerscale)
+						if(istype(src, /mob/living/carbon/human))
+							var/mob/living/carbon/human/M = src
+							if(M.taur == 2)
+								M << "You carefully slither around [tmob]."
+								tmob << "[M]'s huge tail slithers past beside you!"
+							else
+								M << "You carefully step over [tmob]."
+								tmob << "[M] steps over you carefully!"
+						else
+							src << "You carefully step over [tmob]."
+							tmob << "[src] steps over you carefully!"
+					if(tmob.playerscale > src.playerscale)
+						if(istype(tmob, /mob/living/carbon/human))
+							var/mob/living/carbon/human/victim = tmob
+							if(victim.taur == 2)
+								src << "You jump over [victim]'s thick tail."
+								tmob << "[src] bounds over your tail."
+							else
+								src << "You run between [victim]'s legs."
+								tmob << "[src] runs between your legs."
+					return
 				tmob.loc = oldloc
 				now_pushing = 0
 				for(var/mob/living/carbon/slime/slime in view(1,tmob))
 					if(slime.Victim == tmob)
 						slime.UpdateFeed()
 				return
+
+			// NW was here, adding even more options for stomping! FIX THIS
+			if((a_intent == "disarm") && tmob.canmove && canmove)
+				if(abs(src.playerscale - tmob.playerscale) >= 0.75 && ishuman(tmob))
+					if(src.playerscale > tmob.playerscale)
+						now_pushing = 0
+						loc = tmob.loc
+						if(istype(src, /mob/living/carbon/human))
+							var/mob/living/carbon/human/M = src
+							if(M.taur == 2)
+								M << "You carefully squish [tmob] under your tail!"
+								tmob << "[M] pins you under their tail!"
+							else
+								M << "You pin [tmob] beneath your foot!"
+								tmob << "[M] pins you beneath their foot!"
+						else
+							src << "You pin [tmob] beneath your foot!"
+							tmob << "[src] pins you beneath their foot!"
+						tmob.Stun(4)
+						return
+
+			if((a_intent == "hurt") && canmove)
+				if(abs(src.playerscale - tmob.playerscale) >= 0.75 && ishuman(tmob))
+					if(src.playerscale > tmob.playerscale)
+						now_pushing = 0
+						loc = tmob.loc
+						if(istype(src, /mob/living/carbon/human))
+							var/mob/living/carbon/human/M = src
+							if(M.taur == 2)
+								M << "You steamroller over [tmob] with your heavy tail!"
+								tmob << "[M] ploughs you down mercilessly with their heavy tail!"
+							else
+								M << "You bring your foot down heavily upon [tmob]!"
+								tmob << "[M] steps carelessly on your body!"
+						else
+							src << "You bring your foot down heavily upon [tmob]!"
+							tmob << "[src] steps carelessly on your body!"
+						if(istype(tmob, /mob/living/carbon/human))
+							var/mob/living/carbon/human/victim = tmob
+							victim.apply_damage(10,HALLOSS)
+						return
+
+			if((a_intent == "grab") && canmove)
+				if(abs(src.playerscale - tmob.playerscale) >= 0.75 && ishuman(tmob))
+					if(src.playerscale > tmob.playerscale)
+						now_pushing = 0
+						loc = tmob.loc
+						var/obj/item/weapon/holder/micro/D = new(loc)
+						tmob.loc = D
+						D.name = "Micro ([tmob.name])"
+						if(D.mob_can_equip(src,slot_shoes,1))
+							if(istype(src, /mob/living/carbon/human))
+								var/mob/living/carbon/human/M = src
+								if(M.taur == 2)
+									M << "You wrap up [tmob] with your powerful tail!"
+									tmob << "[M] binds you with their powerful tail!"
+								else
+									M << "You clench your toes around [tmob]'s body!"
+									tmob << "[M] grabs your body with their toes!"
+							else
+								src << "You clench your toes around [tmob]'s body!"
+								tmob << "[src] grabs your body with their toes!"
+							equip_to_slot_if_possible(D,slot_shoes,0,1)
+						else
+							if(istype(src, /mob/living/carbon/human))
+								var/mob/living/carbon/human/M = src
+								if(M.taur == 2)
+									M << "You carefully squish [tmob] under your tail!"
+									tmob << "[M] pins you under their tail!"
+								else
+									M << "You pin [tmob] beneath your foot!"
+									tmob << "[M] pins you beneath their foot!"
+							else
+								src << "You pin [tmob] beneath your foot!"
+								tmob << "[src] pins you beneath their foot!"
+							tmob.Stun(4)
+						return
+
 
 			if(istype(tmob, /mob/living/carbon/human) && (FAT in tmob.mutations))
 				if(prob(40) && !(FAT in src.mutations))

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -171,7 +171,8 @@ Please contact me on #coderbus IRC. ~Carn x
 	else
 		var/matrix/M = matrix()
 		M.Scale(playerscale)
-		M.Translate(0, 16*(playerscale-1))
+		if(playerscale >= 1) //If the player is large, align them with the bottom of the tile, otherwise, don't.
+			M.Translate(0, 16*(playerscale-1))
 		src.transform = M
 
 var/global/list/damage_icon_parts = list()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -171,7 +171,7 @@ Please contact me on #coderbus IRC. ~Carn x
 	else
 		var/matrix/M = matrix()
 		M.Scale(playerscale)
-		if(playerscale >= 1) //If the player is large, align them with the bottom of the tile, otherwise, don't.
+		if(playerscale >= RESIZE_NORMAL) //If the player is large, align them with the bottom of the tile, otherwise, don't.
 			M.Translate(0, 16*(playerscale-1))
 		src.transform = M
 

--- a/code/modules/vore/resize.dm
+++ b/code/modules/vore/resize.dm
@@ -21,7 +21,7 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 
 	resize.Scale(size_mod * basesize) //Change the size of the matrix
 
-	if(size_mod >= 1)
+	if(size_mod >= RESIZE_NORMAL)
 		resize.Translate(0, -1 * (1 - size_mod) * basesize * 16) //Move the player up in the tile so their feet align with the bottom
 
 	animate(src,transform = resize, time = 5) //Animate the player resizing

--- a/code/modules/vore/resize.dm
+++ b/code/modules/vore/resize.dm
@@ -21,7 +21,8 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 
 	resize.Scale(size_mod * basesize) //Change the size of the matrix
 
-	resize.Translate(0, -1 * (1 - size_mod) * basesize * 16) //Move the player down or up in the tile so their feet align with the bottom
+	if(size_mod >= 1)
+		resize.Translate(0, -1 * (1 - size_mod) * basesize * 16) //Move the player up in the tile so their feet align with the bottom
 
 	animate(src,transform = resize, time = 5) //Animate the player resizing
 	playerscale = size_mod //Change playerscale so that other items can interact with them


### PR DESCRIPTION
+ Re-add micro foot interactions, addresses Issue #83
+ Make micros centre on tiles again, addresses Issue #82

Also makes the foot code semi-compatible with xenomorphs. Odd behaviour can be exhibited while they're the macro, untested as micro, but unlikely to ever come up outside of admin-run events.

To elaborate on "odd xeno behaviour" - help intent seems fine, harm intent seems fine, grab intent defaults to disarm because xenomorphs don't have a foot slot to equip micros to, but disarm intent just does nothing, pushes them instead.

--- UPDATED 21/10/2015 AT 00:55 BECAUSE BRITISH FUCK YOU GUYS ---

+ Updated resize.dm and update_icons.dm to use the constants instead of integer values