### PR TITLE
Made Remote LOOC Toggleable

### DIFF
--- a/code/game/verbs/ooc.dm
+++ b/code/game/verbs/ooc.dm
@@ -115,15 +115,17 @@
 
 	var/prefix
 	var/admin_stuff
+	var/islocal
 	for(var/client/target in clients)
 		if(target.prefs.toggles & CHAT_LOOC)
+			prefix = ""
 			admin_stuff = ""
+			islocal = (target.mob in heard)
 			if(target in admins)
-				prefix = "(R)"
+				if (!islocal && (target.prefs.runtime_toggles & CHAT_RLOOC))
+					prefix = "(R)"
 				admin_stuff += "/([source.key])"
 				if(target != source.client)
 					admin_stuff += "(<A HREF='?src=\ref[target.holder];adminplayerobservejump=\ref[mob]'>JMP</A>)"
-			if(target.mob in heard)
-				prefix = ""
-			if((target.mob in heard) || (target in admins))
+			if(islocal || prefix)
 				target << "<span class='ooc'><span class='looc'>" + create_text_tag("looc", "LOOC:", target) + " <span class='prefix'>[prefix]</span><EM>[display_name][admin_stuff]:</EM> <span class='message'>[msg]</span></span></span>"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -3,6 +3,7 @@ var/list/admin_verbs_default = list(
 	/datum/admins/proc/show_player_panel,	/*shows an interface for individual players, with various links (links require additional flags*/
 	/client/proc/player_panel,
 	/client/proc/toggleadminhelpsound,	/*toggles whether we hear a sound when adminhelps/PMs are used*/
+	/client/proc/toogle_listen_rlooc,	/*toggles whether we hear remote LOOC */
 	/client/proc/deadmin_self,			/*destroys our own admin datum so we can play as a regular player*/
 	/client/proc/hide_verbs,			/*hides all our adminverbs*/
 	/client/proc/hide_most_verbs,		/*hides all our hideable adminverbs*/

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -38,6 +38,9 @@ datum/preferences
 	var/last_ip
 	var/last_id
 
+	// Runtime preference flags (not saved!)
+	var/runtime_toggles = RUNTIME_TOGGLES_DEFAULT
+
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change
 	var/ooccolor = "#010000"			//Whatever this is set to acts as 'reset' color and is thus unusable as an actual custom color

--- a/code/modules/client/preferences_toggles.dm
+++ b/code/modules/client/preferences_toggles.dm
@@ -120,6 +120,14 @@
 	src << "You will [(prefs.toggles & CHAT_LOOC) ? "now" : "no longer"] see messages on the LOOC channel."
 	feedback_add_details("admin_verb","TLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/client/proc/toogle_listen_rlooc()
+	set name = "Show/Hide Remote LOOC"
+	set category = "Preferences"
+	set desc = "Toggles seeing Remote Local OutOfCharacter chat"
+	prefs.runtime_toggles ^= CHAT_RLOOC
+
+	src << "You will [(prefs.runtime_toggles & CHAT_RLOOC) ? "now" : "no longer"] see remote messages on the LOOC channel."
+	feedback_add_details("admin_verb","TRLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /client/verb/toggle_chattags()
 	set name = "Show/Hide Chat Tags"

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -79,7 +79,7 @@ mob/var/obj/effect/decal/typing_indicator
 	set desc = "Toggles showing an indicator when you are typing emote or say message."
 	prefs.toggles ^= SHOW_TYPING
 	prefs.save_preferences()
-	src << "You will [(prefs.toggles & SHOW_TYPING) ? "no longer" : "now"] display a typing indicator."
+	src << "You will [(prefs.toggles & SHOW_TYPING) ? "now" : "no longer"] display a typing indicator."
 
 	// Clear out any existing typing indicator.
 	if(prefs.toggles & SHOW_TYPING)

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -243,7 +243,7 @@
 #define slot_legs        21
 #define slot_tie         22
 
-// Mob sprite sheets. These need to be strings as numbers 
+// Mob sprite sheets. These need to be strings as numbers
 // cannot be used as associative list keys.
 #define icon_l_hand		"slot_l_hand"
 #define icon_r_hand		"slot_r_hand"
@@ -517,7 +517,7 @@
 
 #define R_MAXPERMISSION 32768 // This holds the maximum value for a permission. It is used in iteration, so keep it updated.
 
-// Preference toggles.
+// Saved Preference toggles.
 #define SOUND_ADMINHELP 1
 #define SOUND_MIDI      2
 #define SOUND_AMBIENCE  4
@@ -536,6 +536,11 @@
 #define CHAT_NOICONS    32768
 
 #define TOGGLES_DEFAULT (SOUND_ADMINHELP|SOUND_MIDI|SOUND_AMBIENCE|SOUND_LOBBY|CHAT_OOC|CHAT_DEAD|CHAT_GHOSTEARS|CHAT_GHOSTSIGHT|CHAT_PRAYER|CHAT_RADIO|CHAT_ATTACKLOGS|CHAT_LOOC)
+
+// Runtime Preference Toggles
+#define CHAT_RLOOC		1
+
+#define RUNTIME_TOGGLES_DEFAULT (CHAT_RLOOC)
 
 #define BE_TRAITOR    1
 #define BE_OPERATIVE  2


### PR DESCRIPTION
* Finished Issue #170 
* The existing "toggles" variable for preference flags was full (BYOND
supports only up to 16 bit bitstrings) Therefore a new one was created; this one is specifically for "runtime" preferences that reset every game start.  (This is both ideal for our RLOOC squelching, which we want to be opt-in, and also convenient because it does not affect the savefile format)
* Add a new bit that toggles hearing (R)LOOC
* Add a new admin verb to toggle the preference bit.
* Changed LOOC verb to not transmit to admins with the CHAT_RLOOC runtime toggle set to false.

Also: :wrench: Fixed: The Typing Indicator Toggle verb works, but the message it prints is the
opposite of what it actually did.

