### PR TITLE
Add 'Custom Species' Setting for Examine

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -56,7 +56,7 @@ datum/preferences
 	var/gender = MALE					//gender of character (well duh)
 	var/age = 30						//age of character
 	var/spawnpoint = "Arrivals Shuttle" //where this character will spawn (0-2).
-	var/b_type = "O-"					//blood type (not-chooseable)
+	var/b_type = "O-"					//blood type
 	var/underwear						//underwear type
 	var/undershirt						//undershirt type
 	var/backbag = 2						//backpack type
@@ -80,6 +80,7 @@ datum/preferences
 	var/g_eyes = 0						//Eye color
 	var/b_eyes = 0						//Eye color
 	var/species = "Human"               //Species datum to use.
+	var/custom_species = null			//Custom species text
 	var/species_preview                 //Used for the species selection window.
 	var/language = "None"				//Secondary language
 	var/list/gear						//Custom/fluff item loadout.
@@ -311,6 +312,7 @@ datum/preferences
 	dat += "(<a href='?_src_=prefs;preference=all;task=random'>&reg;</A>)"
 	dat += "<br>"
 	dat += "Species: <a href='?src=\ref[user];preference=species;task=change'>[species]</a><br>"
+	dat += "Custom Species: <a href='?src=\ref[user];preference=custom_species;task=input'>[custom_species ? custom_species : "None"]</a><br>"
 	dat += "Secondary Language:<br><a href='byond://?src=\ref[user];preference=language;task=input'>[language]</a><br>"
 	dat += "Blood Type: <a href='byond://?src=\ref[user];preference=b_type;task=input'>[b_type]</a><br>"
 	//dat += "Skin Tone: <a href='?_src_=prefs;preference=s_tone;task=input'>[-s_tone + 35]/220<br></a>" //Goodbye Skintone, Orbis
@@ -1278,6 +1280,9 @@ datum/preferences
 						b_hair = 0//hex2num(copytext(new_hair, 6, 8))
 
 					//	s_tone = 0 //Goodbye Skintone, Orbis
+				if("custom_species")
+					var/raw_custom_species = input(user, "Input your character's species:", "Character Preference", custom_species)  as text|null
+					custom_species = sanitize(copytext(raw_custom_species,1,MAX_MESSAGE_LEN))
 
 				if("language")
 					var/languages_available
@@ -1687,6 +1692,7 @@ datum/preferences
 	character.gender = gender
 	character.age = age
 	character.b_type = b_type
+	character.custom_species = custom_species
 
 	character.r_eyes = r_eyes
 	character.g_eyes = g_eyes

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -107,6 +107,7 @@
 	S["gender"]				>> gender
 	S["age"]				>> age
 	S["species"]			>> species
+	S["custom_species"]		>> custom_species
 	S["language"]			>> language
 	S["taur"]				>> taur
 	S["spawnpoint"]			>> spawnpoint
@@ -271,6 +272,7 @@
 	S["gender"]				<< gender
 	S["age"]				<< age
 	S["species"]			<< species
+	S["custom_species"]		<< custom_species
 	S["language"]			<< language
 	S["taur"]				<< taur
 	S["hair_red"]			<< r_hair

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -53,8 +53,11 @@
 				t_him = "her"
 
 	msg += "<EM>[src.name]</EM>"
-	if(species.name != "Human")
-		msg += ", a <b><font color='[species.flesh_color]'>[species.name]</font></b>"
+	if(species.name != "Human" || src.custom_species)
+		if(src.custom_species)
+			msg += ", a <b>[src.custom_species]</b>"
+		else
+			msg += ", a <b><font color='[species.flesh_color]'>[species.name]</font></b>"
 	msg += "!\n"
 
 	//uniform

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -7,6 +7,7 @@
 
 	var/list/hud_list[9]
 	var/embedded_flag	  //To check if we've need to roll for damage on movement while an item is imbedded in us.
+	var/custom_species //For anything it needs to be used for
 
 /mob/living/carbon/human/New(var/new_loc, var/new_species = null)
 


### PR DESCRIPTION
Added a 'Custom Species' that you can set on character setup, which
overrides the examine text species. So if you're a demi you can set this
and your examine text will not omit species (it did this for humans). If
you're an anthro and using sergal and tajara you can put 'red fox' or
whatever and it will say that instead.

preferences.dm: Added custom_species and entry on character setup screen,
and to add this to the character.custom_species variable

preferences_safefile.dm: Updated savefile to save custom_preferences

carbon/human/examine.dm: Added override for species examine text if
custom_species is defined

carbon/human/human.dm: Added custom_species variable (undefined)