### PR TITLE
Fix Issue #161 (Telco Machine Construction)

### DIFF
--- a/code/game/machinery/machinery.dm
+++ b/code/game/machinery/machinery.dm
@@ -105,7 +105,7 @@ Class Procs:
 	var/idle_power_usage = 0
 	var/active_power_usage = 0
 	var/power_channel = EQUIP //EQUIP, ENVIRON or LIGHT
-	var/list/component_parts = null //list of all the parts used to build it, if made from certain kinds of frames.
+	var/list/component_parts = list() //list of all the parts used to build it, if made from certain kinds of frames.
 	var/uid
 	var/panel_open = 0
 	var/global/gl_uid = 1


### PR DESCRIPTION
* Telco machines did not instantiate component_parts in constructor.  To
prevent stuff that assumes it is a list from failing, we init to empty
list so all machines behave consistently