### PR TITLE
Taur Enhancement and Cloning

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -33,6 +33,8 @@ var/global/list/poster_designs = list()
 var/list/obj/item/device/uplink/world_uplinks = list()
 
 //Preferences stuff
+	// Taur body type
+var/global/list/taur_styles_list = list()
 	//Hairstyles
 var/global/list/hair_styles_list = list()			//stores /datum/sprite_accessory/hair indexed by name
 var/global/list/hair_styles_male_list = list()
@@ -58,6 +60,12 @@ var/global/list/backbaglist = list("Nothing", "Backpack", "Satchel", "Satchel Al
 
 /proc/makeDatumRefLists()
 	var/list/paths
+
+	// Taurs - Initialise all /datum/sprite_accessory/taur into an list indexed by taur type name
+	paths = typesof(/datum/sprite_accessory/taur) - /datum/sprite_accessory/taur
+	for(var/path in paths)
+		var/datum/sprite_accessory/taur/H = new path()
+		taur_styles_list[H.name] = H
 
 	//Hair - Initialise all /datum/sprite_accessory/hair into an list indexed by hair-style name
 	paths = typesof(/datum/sprite_accessory/hair) - /datum/sprite_accessory/hair

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -142,6 +142,8 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	if(character.tail_style)
 		tail_style = tail_styles_list.Find(character.tail_style.type)
 
+	// Taur
+	var/taur	= character.taur // Taur is already stored as an integer
 
 	SetUIValueRange(DNA_UI_HAIR_R,    character.r_hair,    255,    1)
 	SetUIValueRange(DNA_UI_HAIR_G,    character.g_hair,    255,    1)
@@ -167,6 +169,7 @@ var/global/list/datum/dna/gene/dna_genes[0]
 	SetUIValueRange(DNA_UI_BEARD_STYLE, beard, 		facial_hair_styles_list.len,1)
 	SetUIValueRange(DNA_UI_EAR_STYLE,	ear_style,	ear_styles_list.len,		1)
 	SetUIValueRange(DNA_UI_TAIL_STYLE,	tail_style,	tail_styles_list.len,		1)
+	SetUIValueRange(DNA_UI_TAUR_BODY, 	taur,  		taur_styles_list.len,       1)
 
 	UpdateUI()
 

--- a/code/game/dna/dna2_helpers.dm
+++ b/code/game/dna/dna2_helpers.dm
@@ -182,6 +182,12 @@
 		else if((0 < tail) && (tail <= tail_styles_list.len))
 			H.tail_style = tail_styles_list[tail_styles_list[tail]]
 
+		// Taur
+		var/taur = dna.GetUIValueRange(DNA_UI_TAUR_BODY,taur_styles_list.len)
+		if (taur == 0)
+			H.taur = 0
+		else if((0 < taur) && (taur <= taur_styles_list.len))
+			H.taur = taur // Taur is stored as the index for historical reasons
 
 		H.update_body(0)
 		H.update_hair()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -319,7 +319,7 @@ datum/preferences
 	dat += "Blood Type: <a href='byond://?src=\ref[user];preference=b_type;task=input'>[b_type]</a><br>"
 	//dat += "Skin Tone: <a href='?_src_=prefs;preference=s_tone;task=input'>[-s_tone + 35]/220<br></a>" //Goodbye Skintone, Orbis
 	//dat += "Skin pattern: <a href='byond://?src=\ref[user];preference=skin_style;task=input'>Adjust</a><br>"
-	dat += "Taur body: <a href='byond://?src=\ref[user];preference=taurbody;task=input'>[taur]</a><br>"
+	dat += "Taur body: <a href='byond://?src=\ref[user];preference=taurbody;task=input'>[taur > 0 && taur <= taur_styles_list.len ? taur_styles_list[taur] : "None"]</a><br>"
 	dat += "<a href='?_src_=prefs;preference=t_tone;task=input'>Taur colour</a> <font face='fixedsys' size='3' color='#[num2hex(r_taur, 2)][num2hex(g_taur, 2)][num2hex(b_taur, 2)]'><table style='display:inline;' bgcolor='#[num2hex(r_taur, 2)][num2hex(g_taur, 2)][num2hex(b_taur)]'><tr><td>__</td></tr></table></font> "
 	dat += "(<a href='?_src_=prefs;preference=skin2taur;task=input'>Skin tone to taur colour</A>)<br>"
 	dat += "Ear Style: <a href='byond://?src=\ref[user];preference=ear_style;task=input'>[ear_style ? "Custom" : "Normal"]</a><br>"
@@ -1402,10 +1402,9 @@ datum/preferences
 			//			if(new_s_tone)
 			//				s_tone = 35 - max(min( round(new_s_tone), 220),1)
 				if("taurbody")
-					var/list/taur_types = list("None","Fluffy","Naga","Horse","Cow","Lizard","Spider")
-					var/new_taur = input(user, "Choose your character's taur body:", "Character Preference") as null|anything in taur_types  //list( "A+", "A-", "B+", "B-", "AB+", "AB-", "O+", "O-" )
-					taur = taur_types.Find(new_taur) - 1
-
+					var/list/taur_types = list("None") + taur_styles_list
+					var/new_taur = input(user, "Choose your character's taur body:", "Character Preference") as null|anything in taur_types
+					taur = taur_types.Find(new_taur) - 1 // Subtract one to adjust for "None" being tacked on.
 
 				if("t_tone")
 					var/new_t_tone = input(user, "Choose your character's taur-tone:", "Character Preference")  as color|null

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -213,7 +213,7 @@
 	be_random_name	= sanitize_integer(be_random_name, 0, 1, initial(be_random_name))
 	gender			= sanitize_gender(gender)
 	age				= sanitize_integer(age, AGE_MIN, AGE_MAX, initial(age))
-	taur			= sanitize_integer(taur, 0, 8, initial(taur))
+	taur			= sanitize_integer(taur, 0, taur_styles_list.len, initial(taur))
 	r_hair			= sanitize_integer(r_hair, 0, 255, initial(r_hair))
 	g_hair			= sanitize_integer(g_hair, 0, 255, initial(g_hair))
 	b_hair			= sanitize_integer(b_hair, 0, 255, initial(b_hair))

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -913,38 +913,18 @@ proc/get_damage_icon_part(damage_state, body_part)
 
 	if(update_icons) update_icons()
 
-#define TOTAL_TAUR_ICONS 6 //If more icons are ever added, or removed, this _has_ to be updated accordingly.
 /mob/living/carbon/human/proc/update_tail_showing(var/update_icons=1)
 	overlays_standing[TAIL_LAYER] = null
 
-	if(taur && taur <= TOTAL_TAUR_ICONS) //taur is True and not exceeding the actual number of possible options
-
-		var/icon/taur_s //Holder value to transfer onto the mob. Null by default.
-
-		switch(taur) //Shorthand for if(taur == [value])
-
-			if(1)	//Wolf
-				taur_s = new/icon("icon" = 'icons/effects/taurs.dmi', "icon_state" = "wolf_s")
-
-			if(2)	//Naga
-				taur_s = new/icon("icon" = 'icons/effects/taurs.dmi', "icon_state" = "naga_s")
-
-			if(3)	//Horse
-				taur_s = new/icon("icon" = 'icons/effects/taurs.dmi', "icon_state" = "horse_s")
-
-			if(4)	//Cow
-				taur_s = new/icon("icon" = 'icons/effects/taurs.dmi', "icon_state" = "cow_s")
-
-			if(5)	//Lizard
-				taur_s = new/icon("icon" = 'icons/effects/taurs.dmi', "icon_state" = "lizard_s")
-
-			if(6)	//Spider
-				taur_s = new/icon("icon" = 'icons/effects/taurs.dmi', "icon_state" = "spider_s")
-
-		if(!taur_s)	return //Avoid runtimes if taur_s does not get a value
-
-		taur_s.Blend(rgb(r_taur, g_taur, b_taur), ICON_MULTIPLY) //Note, this could be moved to the switch above if needed, but currently every taur uses _MULTIPLY
-		overlays_standing[TAIL_LAYER] = image(taur_s, "pixel_x" = (-16*playerscale)) //Apply taur to overlays, with required pixel offset applied.
+	if(taur && taur <= taur_styles_list.len) //taur is True and not exceeding the actual number of possible options
+		var/datum/sprite_accessory/taur/taur_style = taur_styles_list[taur_styles_list[taur]]  // Taur is int, list is by name
+		if(taur_style)
+			var/icon/taur_s = new/icon("icon" = taur_style.icon, "icon_state" = taur_style.icon_state)
+			if(taur_style.do_colouration)
+				//Note, this could be moved to the switch above if needed, but currently every taur uses _MULTIPLY
+				taur_s.Blend(rgb(r_taur, g_taur, b_taur), ICON_MULTIPLY)
+				 //Apply taur to overlays, with required pixel offset applied.
+				overlays_standing[TAIL_LAYER] = image(taur_s, "pixel_x" = (-16*playerscale))
 
 	else if(src.tail_style)
 		if(!wear_suit || !(wear_suit.flags_inv & HIDETAIL) && !istype(wear_suit, /obj/item/clothing/suit/space))

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -1021,3 +1021,39 @@
 	desc = ""
 	icon_state = "rosey"
 
+/*
+////////////////////////////
+/  =--------------------=  /
+/  == Taur Definitions ==  /
+/  =--------------------=  /
+////////////////////////////
+*/
+
+/datum/sprite_accessory/taur
+	name = "You should not see this..."
+	do_colouration = 1
+	icon = 'icons/effects/taurs.dmi'
+
+/datum/sprite_accessory/taur/wolf
+	name = "Wolf"
+	icon_state = "wolf_s"
+
+/datum/sprite_accessory/taur/naga
+	name = "Naga"
+	icon_state = "naga_s"
+
+/datum/sprite_accessory/taur/horse
+	name = "Horse"
+	icon_state = "horse_s"
+
+/datum/sprite_accessory/taur/cow
+	name = "Cow"
+	icon_state = "cow_s"
+
+/datum/sprite_accessory/taur/lizard
+	name = "Lizard"
+	icon_state = "lizard_s"
+
+/datum/sprite_accessory/taur/spider
+	name = "Spider"
+	icon_state = "spider_s"


### PR DESCRIPTION
* Enhance how taur-body sprites are implemented by replacing hard coded lists and switch statements with a new datum which defines details about taurs.
* Changed the load/save and icon drawing to reference the list of singleton datum instances instead.
* Now Taur-type is Block 19 of UI in DNA.

Advantages:
* New taur types can be added simply by appending an additional datum. No editing elsewhere in code required, it is all automatic.
* Taurs show up on the character setup screen by name instead of just by number.
* **Taurs stay tauric when cloned!** 
* No more hard coded numeric indexes, its all data-driven code.
