### PR TITLE
Constructable Kitchen Machines

### DIFF
--- a/VOREStation.dme
+++ b/VOREStation.dme
@@ -639,6 +639,7 @@
 #include "code\game\objects\items\weapons\circuitboards\computer\telecomms.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\biogenerator.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\cloning.dm"
+#include "code\game\objects\items\weapons\circuitboards\machinery\kitchen.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\pacman.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\power.dm"
 #include "code\game\objects\items\weapons\circuitboards\machinery\recharge_station.dm"

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -52,6 +52,11 @@
 
 /obj/machinery/gibber/New()
 	..()
+	component_parts = list()
+	component_parts += new /obj/item/weapon/circuitboard/gibber(null, type)
+	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/weapon/stock_parts/manipulator(null)
+	RefreshParts()
 	src.overlays += image('icons/obj/kitchen.dmi', "grjam")
 
 /obj/machinery/gibber/update_icon()
@@ -85,6 +90,13 @@
 	usr << "The safety guard is [emagged ? "<span class='danger'>disabled</span>" : "enabled"]."
 
 /obj/machinery/gibber/attackby(var/obj/item/W, var/mob/user)
+	// Handle default machine operations
+	if(default_deconstruction_screwdriver(user, W))
+		return
+	if(default_deconstruction_crowbar(user, W))
+		return
+	if(default_part_replacement(user, W))
+		return
 
 	if(istype(W,/obj/item/weapon/card))
 		if(!allowed(user) && !istype(W,/obj/item/weapon/card/emag))

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -47,6 +47,14 @@
 		// impure carbon. ~Z
 		acceptable_items |= /obj/item/weapon/holder
 		acceptable_items |= /obj/item/weapon/reagent_containers/food/snacks/grown
+	// Component Parts
+	component_parts = list()
+	component_parts += new /obj/item/weapon/circuitboard/microwave(null, type)
+	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/stack/cable_coil(null)
+	component_parts += new /obj/item/stack/cable_coil(null)
+	component_parts += new /obj/item/weapon/stock_parts/console_screen(null)
+	RefreshParts()
 
 /*******************
 *   Item Adding
@@ -65,6 +73,7 @@
 					"\blue You have fixed part of the microwave." \
 				)
 				src.broken = 1 // Fix it a bit
+			return
 		else if(src.broken == 1 && istype(O, /obj/item/weapon/wrench)) // If it's broken and they're doing the wrench
 			user.visible_message( \
 				"\blue [user] starts to fix part of the microwave.", \
@@ -79,10 +88,21 @@
 				src.broken = 0 // Fix it!
 				src.dirty = 0 // just to be sure
 				src.flags = OPENCONTAINER
+			return
 		else
 			user << "\red It's broken!"
 			return 1
-	else if(src.dirty==100) // The microwave is all dirty so can't be used!
+
+	// Handle default machine operations
+	if(default_deconstruction_screwdriver(user, O))
+		return
+	if(default_deconstruction_crowbar(user, O))
+		return
+	if(default_part_replacement(user, O))
+		return
+
+	// Handle microwave operation
+	if(src.dirty==100) // The microwave is all dirty so can't be used!
 		if(istype(O, /obj/item/weapon/reagent_containers/spray/cleaner)) // If they're trying to clean it then let them
 			user.visible_message( \
 				"\blue [user] starts to clean the microwave.", \

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -33,6 +33,12 @@
 	else
 		wires = new/datum/wires/smartfridge(src)
 
+	component_parts = list()
+	component_parts += new /obj/item/weapon/circuitboard/smartfridge(null, type)
+	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/weapon/stock_parts/manipulator(null)
+	RefreshParts()
+
 /obj/machinery/smartfridge/Del()
 	del(wires) // qdel
 	..()
@@ -182,6 +188,13 @@
 		if(panel_open)
 			overlays += image(icon, icon_panel)
 		nanomanager.update_uis(src)
+		return
+
+	// Handle default machine operations
+	if(default_deconstruction_crowbar(user, O))
+		return
+
+	if(default_part_replacement(user, O))
 		return
 
 	if(istype(O, /obj/item/device/multitool)||istype(O, /obj/item/weapon/wirecutters))

--- a/code/game/objects/items/weapons/circuitboards/machinery/kitchen.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/kitchen.dm
@@ -1,0 +1,49 @@
+#ifndef T_BOARD
+#error T_BOARD macro is not defined but we need it!
+#endif
+
+/obj/item/weapon/circuitboard/microwave
+	name = T_BOARD("microwave")
+	build_path = "/obj/machinery/microwave"
+	contain_parts = 0
+	board_type = "machine"
+	origin_tech = "programming=1;magnets=2"
+	req_components = list(
+							"/obj/item/weapon/stock_parts/micro_laser" = 1,
+							"/obj/item/weapon/stock_parts/matter_bin" = 1,
+							"/obj/item/stack/cable_coil" = 2,
+							"/obj/item/weapon/stock_parts/console_screen" = 1)
+
+/obj/item/weapon/circuitboard/gibber
+	name = T_BOARD("gibber")
+	build_path = "/obj/machinery/gibber"
+	contain_parts = 0
+	board_type = "machine"
+	origin_tech = "programming=1;materials=2"
+	req_components = list(
+							"/obj/item/weapon/stock_parts/matter_bin" = 1,
+							"/obj/item/weapon/stock_parts/manipulator" = 1)
+
+/obj/item/weapon/circuitboard/smartfridge
+	name = T_BOARD("smartfridge")
+	build_path = "/obj/machinery/smartfridge"
+	contain_parts = 0
+	board_type = "machine"
+	origin_tech = "programming=1;magnets=2;engineering=2"
+	req_components = list(
+							"/obj/item/weapon/stock_parts/matter_bin" = 1,
+							"/obj/item/weapon/stock_parts/manipulator" = 1)
+
+/obj/item/weapon/circuitboard/smartfridge/attackby(var/obj/item/I, var/mob/user)
+	if(istype(I, /obj/item/weapon/screwdriver))
+		var/list/fridges = list( "/obj/machinery/smartfridge" = "default",
+								 "/obj/machinery/smartfridge/seeds" = "seeds",
+								 "/obj/machinery/smartfridge/drinks" = "drinks",
+								 "/obj/machinery/smartfridge/secure/medbay" = "medicine",
+								 "/obj/machinery/smartfridge/secure/extract" = "slimes",
+								 "/obj/machinery/smartfridge/secure/virology" = "viruses")
+
+		var/position = fridges.Find(build_path, fridges)
+		position = (position == fridges.len) ? 1 : (position + 1)
+		build_path = fridges[position]
+		user << "<span class='notice'>You set the board to [fridges[build_path]].</span>"

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -1008,6 +1008,28 @@ datum/design/circuit/recharge_station
 	req_tech = list("programming" = 3, "engineering" = 2)
 	build_path = /obj/item/weapon/circuitboard/recharge_station
 
+////////////////////////////////////////
+/////////Civilian Circuit Boards////////
+////////////////////////////////////////
+
+datum/design/circuit/microwave
+	name = "Machine Design (Microwave Board)"
+	id = "microwave"
+	req_tech = list("programming" = 1, "magnets" = 2)
+	build_path = /obj/item/weapon/circuitboard/microwave
+
+datum/design/circuit/gibber
+	name = "gibber"
+	id = "gibber"
+	req_tech = list("programming" = 1, "materials" = 2)
+	build_path = /obj/item/weapon/circuitboard/gibber
+
+datum/design/circuit/smartfridge
+	name = "smartfridge"
+	id = "smartfridge"
+	req_tech = list("programming" = 1, "magnets" = 2, "engineering" = 2)
+	build_path = /obj/item/weapon/circuitboard/smartfridge
+
 /////////////////////////////////////////
 ////////Power Stuff Circuitboards////////
 /////////////////////////////////////////


### PR DESCRIPTION
Make kitchen machines (Microwave, Gibber, and Smartfridge) constructable

* Add a circuit board item for each so its constructable
* Add circuit boards to R&D datums so the boards are printable
* Add components to New() for each
* Add handlers for screwdriver/crowbar to each so they are
de-constructable.
* Add part replacer handler to each so parts are replacable.