### PR TITLE
Atmos Sensor Computers (Fix #234)

### DIFF
--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -20,3 +20,8 @@
 
 	origin_tech = "magnets=1;engineering=1"
 	var/obj/machinery/telecomms/buffer // simple machine buffer for device linkage
+	var/obj/link_buffer = null // For linking up stuff that isn't telecoms
+
+/obj/item/device/multitool/afterattack(var/atom/A, var/mob/user, var/proximity, var/params)
+	link_buffer = A
+	return ..()

--- a/code/game/objects/items/weapons/circuitboards/computer/air_management.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/air_management.dm
@@ -1,11 +1,13 @@
 #ifndef T_BOARD
-#error T_BOARD macro is not defined but we need it! 
+#error T_BOARD macro is not defined but we need it!
 #endif
 
 /obj/item/weapon/circuitboard/air_management
 	name = T_BOARD("atmosphere monitoring console")
 	build_path = /obj/machinery/computer/general_air_control
 	var/frequency = 1439
+	var/list/sensors = list()
+
 /obj/item/weapon/circuitboard/air_management/tank_control
 	name = T_BOARD("tank control")
 	build_path = /obj/machinery/computer/general_air_control/large_tank_control
@@ -20,8 +22,27 @@
 
 /obj/item/weapon/circuitboard/air_management/construct(var/obj/machinery/computer/general_air_control/C)
 	if (..(C))
-		C.frequency = frequency
+		C.set_frequency(frequency)
+		C.sensors = sensors
 
 /obj/item/weapon/circuitboard/air_management/deconstruct(var/obj/machinery/computer/general_air_control/C)
 	if (..(C))
 		frequency = C.frequency
+		sensors = C.sensors.Copy()
+
+/obj/item/weapon/circuitboard/air_management/attackby(var/obj/I, var/mob/user)
+	if(istype(I, /obj/item/device/multitool))
+		var/obj/item/device/multitool/MT = I
+		if (MT.link_buffer && istype(MT.link_buffer, /obj/machinery/air_sensor))
+			var/obj/machinery/air_sensor/sensor = MT.link_buffer
+			playsound(src.loc, 'sound/items/Screwdriver2.ogg', 50, 1)
+			frequency = sensor.frequency
+			sensors[sensor.id_tag] = sensor.name
+			user << "\blue Copied link data from multitool. Frequency set to [format_frequency(sensor.frequency)] and [sensor] added to the sensor list."
+			return 1
+	else
+		return ..()
+
+/obj/item/weapon/circuitboard/air_management/examine(mob/user)
+	if(..(user, 1))
+		user << "Dip switches show the frequency is set to [format_frequency(frequency)]"


### PR DESCRIPTION
* Circuit board needs to retain not only the frequency but also list of
sensor IDs in order to properly rebuild the same computer.
* You cannot just set the frequency var, you must call set_frequency()
for it to take effect
* While we are here, lets make examining the board show the frequency
configured.
* While we are here, lets make it possible to link up air sensors and
atmos computers!