### PR TITLE
Re-arranged update_icons layers

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -113,11 +113,11 @@ Please contact me on #coderbus IRC. ~Carn x
 #define SHOES_LAYER				6
 #define GLOVES_LAYER			7
 #define SUIT_LAYER				8
-#define TAIL_LAYER				9		//bs12 specific. this hack is probably gonna come back to haunt me
-#define GLASSES_LAYER			10
-#define BELT_LAYER				11		//Possible make this an overlay of somethign required to wear a belt?
-#define SUIT_STORE_LAYER		12
-#define BACK_LAYER				13
+#define GLASSES_LAYER			9
+#define BELT_LAYER				10		//Possible make this an overlay of somethign required to wear a belt?
+#define SUIT_STORE_LAYER		11
+#define BACK_LAYER				12
+#define TAIL_LAYER				13		//bs12 specific. this hack is probably gonna come back to haunt me
 #define HAIR_LAYER				14		//TODO: make part of head layer?
 #define EARS_LAYER				15
 #define FACEMASK_LAYER			16


### PR DESCRIPTION
Moved tail layer down. Prevents it from rendering under back and suit
slot.

There are downsides to any layer placement. Nothing will make this perfect
unfortunately. Some placements decide whether something looks good from
the front or back, but not good from both.

And not every suit slot item is really a back item. Stun batons generally
aren't. But MOST are weapons worn on the back, and we can only make it
look good for MOST things, sadly.