### PR TITLE
simple_animal changes

### DIFF
--- a/VOREStation.dme
+++ b/VOREStation.dme
@@ -1577,6 +1577,7 @@
 #include "code\modules\vore\belly\belly.dm"
 #include "code\modules\vore\belly\belly_balls.dm"
 #include "code\modules\vore\belly\belly_boobs.dm"
+#include "code\modules\vore\belly\belly_simple.dm"
 #include "code\modules\vore\belly\belly_stomach.dm"
 #include "code\modules\vore\belly\belly_womb.dm"
 #include "code\modules\vore\voretype\anal.dm"

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -494,7 +494,7 @@
 
 /mob/living/proc/escape_inventory(obj/item/weapon/holder/H)
 	if(H != src.loc) return
-	
+
 	var/mob/M = H.loc //Get our mob holder (if any).
 
 	if(istype(M))

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -36,8 +36,7 @@
 					sleep(30)
 					if(M in oview(1, src))
 						custom_emote(1, "swallows down [M] into their hungry gut!")
-						M.loc = src
-						stomach_contents.Add(M)
+						src.insides.nom_mob(M)
 						playsound(src, 'sound/vore/gulp.ogg', 100, 1)
 					else
 						M << "You just manage to slip away from [src]'s jaws before you can be sent to a fleshy prison!"
@@ -58,27 +57,30 @@
 		break
 
 	if(!stat && !resting && !buckled) //SEE A MICRO AND ARE A PREDATOR, EAT IT!
-		for(var/mob/living/carbon/human/food in oview(src, 3))
+		for(var/mob/living/carbon/human/food in oview(src, 5))
+
 			if(food.playerscale <= RESIZE_A_SMALLTINY)
 				if(prob(10))
 					custom_emote(1, pick("eyes [food] hungrily!","licks their lips and turns towards [food] a little!","purrs as they imagine [food] being in their belly."))
 					break
 				else
-					if(prob(2))
+					if(prob(5))
 						movement_target = food
 						break
+
 		for(var/mob/living/carbon/human/bellyfiller in oview(1, src))
+			if(bellyfiller in src.prey_excludes)
+				continue
+
 			if(bellyfiller.playerscale <= RESIZE_A_SMALLTINY && isPredator)
 				movement_target = null
 				custom_emote(1, pick("slurps [bellyfiller] with their sandpapery tongue.","looms over [bellyfiller] with their maw agape.","sniffs at [bellyfiller], their belly grumbling hungrily."))
-				sleep(2)
-
-				custom_emote(1, "scoops [bellyfiller] into their maw!")
+				sleep(10)
+				custom_emote(1, "starts to scoop [bellyfiller] into their maw!")
 				sleep(swallowTime)
 				if(bellyfiller in oview(1, src))
 					custom_emote(1, "swallows down [bellyfiller] with a happy purr!")
-					bellyfiller.loc = src
-					stomach_contents.Add(bellyfiller)
+					src.insides.nom_mob(bellyfiller)
 					msg_admin_attack("[key_name(bellyfiller)] got eaten by [src]!")
 					playsound(src, 'sound/vore/gulp.ogg', 100, 1)
 				else
@@ -112,7 +114,7 @@
 
 	if(movement_target)
 		stop_automated_movement = 1
-		walk_to(src,movement_target,0,3)
+		walk_to(src,movement_target,0,10)
 
 /mob/living/simple_animal/cat/proc/handle_flee_target()
 	//see if we should stop fleeing
@@ -266,3 +268,42 @@
 /mob/living/simple_animal/cat/kitten/New()
 	gender = pick(MALE, FEMALE)
 	..()
+
+//////
+// Vorestuff that has to be here because constructors are the only place they can be.
+//////
+
+/* I can't think of cat messages. I am a fox. Please put some in and remove this comment. :( -Aro
+/mob/living/simple_animal/cat/stomach_emotes = list(
+							"",
+							"",
+							"",
+							"",
+							"",
+							"")
+
+/mob/living/simple_animal/cat/stomach_emotes_d = list(
+							"",
+							"",
+							"",
+							"",
+							"",
+							"")
+
+*/
+
+/mob/living/simple_animal/cat/fluff/Runtime/stomach_emotes = list(
+							"Runtime's stomach kneads gently on you and you're fairly sure you can hear her start purring.",
+							"Most of what you can hear are slick noises, Runtime breathing, and distant purring.",
+							"Runtime seems perfectly happy to have you in there. She lays down for a moment to groom and squishes you against the walls.",
+							"The CMO's pet seems to have found a patient of her own, and is treating them with warm, wet kneading walls.",
+							"Runtime mostly just lazes about, and you're left to simmer in the hot, slick guts unharmed.",
+							"Runtime's master might let you out of this fleshy prison, eventually. Maybe.")
+
+/mob/living/simple_animal/cat/fluff/Runtime/stomach_emotes_d = list(
+							"Runtime's stomach is treating you rather like a mouse, kneading acids into you with vigor.",
+							"A thick dollop of bellyslime drips from above while the CMO's pet's gut works on churning you up.",
+							"Runtime seems to have decided you're food, based on the acrid air in her guts and the pooling fluids.",
+							"Runtime's stomach tries to claim you, kneading and pressing inwards again and again against your form.",
+							"Runtime flops onto their side for a minute, spilling acids over your form as you remain trapped in them.",
+							"The CMO's pet doesn't seem to think you're any different from any other meal. At least, their stomach doesn't.")

--- a/code/modules/mob/living/simple_animal/friendly/fox.dm
+++ b/code/modules/mob/living/simple_animal/friendly/fox.dm
@@ -35,8 +35,7 @@
 					sleep(30)
 					if(M in oview(1, src))
 						custom_emote(1, "swallows down [M] into their hungry gut!")
-						M.loc = src
-						stomach_contents.Add(M)
+						src.insides.nom_mob(M)
 						playsound(src, 'sound/vore/gulp.ogg', 100, 1)
 					else
 						M << "You just manage to slip away from [src]'s jaws before you can be sent to a fleshy prison!"
@@ -57,27 +56,30 @@
 		break
 
 	if(!stat && !resting && !buckled) //SEE A MICRO AND ARE A PREDATOR, EAT IT!
-		for(var/mob/living/carbon/human/food in oview(src, 3))
+		for(var/mob/living/carbon/human/food in oview(src, 5))
+
 			if(food.playerscale <= RESIZE_A_SMALLTINY)
 				if(prob(10))
 					custom_emote(1, pick("eyes [food] hungrily!","licks their lips and turns towards [food] a little!","pants as they imagine [food] being in their belly."))
 					break
 				else
-					if(prob(2))
+					if(prob(5))
 						movement_target = food
 						break
+
 		for(var/mob/living/carbon/human/bellyfiller in oview(1, src))
+			if(bellyfiller in src.prey_excludes)
+				continue
+
 			if(bellyfiller.playerscale <= RESIZE_A_SMALLTINY && isPredator)
 				movement_target = null
 				custom_emote(1, pick("slurps [bellyfiller] with their slimey tongue.","looms over [bellyfiller] with their maw agape.","sniffs at [bellyfiller], their belly grumbling hungrily."))
-				sleep(2)
-
-				custom_emote(1, "scoops [bellyfiller] into their maw!")
+				sleep(10)
+				custom_emote(1, "starts to scoop [bellyfiller] into their maw!")
 				sleep(swallowTime)
 				if(bellyfiller in oview(1, src))
 					custom_emote(1, "swallows down [bellyfiller] with a happy yap!")
-					bellyfiller.loc = src
-					stomach_contents.Add(bellyfiller)
+					src.insides.nom_mob(bellyfiller)
 					msg_admin_attack("[key_name(bellyfiller)] got eaten by [src]!")
 					playsound(src, 'sound/vore/gulp.ogg', 100, 1)
 				else
@@ -111,7 +113,7 @@
 
 	if(movement_target)
 		stop_automated_movement = 1
-		walk_to(src,movement_target,0,3)
+		walk_to(src,movement_target,0,10)
 
 /mob/living/simple_animal/fox/proc/handle_flee_target()
 	//see if we should stop fleeing
@@ -251,3 +253,41 @@
 	desc = "Renault, the Captain's trustworthy fox.I wonder what it says?"
 	isPredator = 1
 	befriend_job = "Captain"
+
+
+//////
+// Vorestuff that has to be here because constructors are the only place they can be.
+//////
+
+/mob/living/simple_animal/fox/stomach_emotes = list(
+							"The foxguts knead and churn around you harmlessly.",
+							"With a loud glorp, some air shifts inside the belly.",
+							"A thick drop of warm bellyslime drips onto you from above.",
+							"The fox turns suddenly, causing you to shift a little.",
+							"During a moment of relative silence, you can hear the fox breathing.",
+							"The slimey stomach walls squeeze you lightly, then relax.")
+
+/mob/living/simple_animal/fox/stomach_emotes_d = list(
+							"The guts knead at you, trying to work you into thick soup.",
+							"You're ground on by the slimey walls, treated like a mouse.",
+							"The acrid air is hard to breathe, and stings at your lungs.",
+							"You can feel the acids coating you, ground in by the slick walls.",
+							"The fox's stomach churns hungrily over your form, trying to take you.",
+							"With a loud glorp, the stomach spills more acids onto you.")
+
+
+/mob/living/simple_animal/fox/fluff/Renault/stomach_emotes = list(
+							"Renault's stomach walls squeeze around you more tightly for a moment, before relaxing, as if testing you a bit.",
+							"There's a sudden squeezing as Renault presses a forepaw against his gut over you, squeezng you against the slick walls.",
+							"The 'head fox' has a stomach that seems to think you belong to it. It might be hard to argue, as it kneads at your form.",
+							"If being in the captain's fox is a promotion, it might not feel like one. The belly just coats you with more thick foxslime.",
+							"It doesn't seem like Renault wants to let you out. The stomach and owner possessively squeeze around you.",
+							"Renault's stomach walls squeeze closer, as he belches quietly, before swallowing more air. Does he do that on purpose?")
+
+/mob/living/simple_animal/fox/fluff/Renault/stomach_emotes_d = list(
+							"Renault's stomach walls grind hungrily inwards, kneading acids against your form, and treating you like any other food.",
+							"The captain's fox impatiently kneads and works acids against you, trying to claim your body for fuel.",
+							"The walls knead in firmly, squeezing and tossing you around briefly in disorienting aggression.",
+							"Renault belches, letting the remaining air grow more acrid. It burns your lungs with each breath.",
+							"A thick glob of acids drip down from above, adding to the pool of caustic fluids in Renault's belly.",
+							"There's a loud gurgle as the stomach declares the intent to make you a part of Renault.")

--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -418,8 +418,7 @@
 							sleep(swallowTime)
 							if(istype(held_item,/obj/item/weapon/holder/micro))
 								custom_emote(1, "swallows [held_item] alive, a little lump sliding into its gut!")
-								M.loc = src
-								stomach_contents.Add(M)
+								src.insides.nom_mob(held_item)
 								msg_admin_attack("[key_name(M)] got eaten by [src]!")
 								playsound(src, 'sound/vore/gulp.ogg', 100, 1)
 			parrot_state = PARROT_SWOOP | PARROT_RETURN
@@ -768,3 +767,26 @@
 	parrot_state = PARROT_SWOOP | PARROT_ATTACK //Attack other animals regardless
 	icon_state = "parrot_fly"
 	return success
+
+
+
+//////
+// Vorestuff that has to be here because constructors are the only place they can be.
+//////
+/* Dunno about parrot emotes. Please add some and uncomment this! -Aro
+/mob/living/simple_animal/parrot/stomach_emotes = list(
+							"",
+							"",
+							"",
+							"",
+							"",
+							"")
+
+/mob/living/simple_animal/parrot/stomach_emotes_d = list(
+							"",
+							"",
+							"",
+							"",
+							"",
+							"")
+*/

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -58,8 +58,10 @@
 	..()
 	verbs -= /mob/verb/observe
 	// Vore Code Start
-	// Setup the types of bellies present.
-	internal_contents["Stomach"] = new /datum/belly/stomach(src)
+	// Setup the types of bellies present
+
+	insides = new /datum/belly/simple(src)
+	internal_contents["Insides"] = insides
 	vorifice = SINGLETON_VORETYPE_INSTANCES["Oral Vore"]
 	// Vore Code End
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -61,7 +61,7 @@
 	// Setup the types of bellies present
 
 	insides = new /datum/belly/simple(src)
-	internal_contents["Insides"] = insides
+	internal_contents["Stomach"] = insides
 	vorifice = SINGLETON_VORETYPE_INSTANCES["Oral Vore"]
 	// Vore Code End
 

--- a/code/modules/vore/belly/belly_simple.dm
+++ b/code/modules/vore/belly/belly_simple.dm
@@ -1,0 +1,140 @@
+//
+//	A simple belly type for mobs that only have one type.
+//
+
+/datum/belly/simple
+	belly_type = "Simple"
+	belly_name = "insides"
+	inside_flavor = "There is nothing interesting about these insides."
+
+	var/emoteBetween = 600 					//How long between belly emotes
+	var/emoteAfter = 0						//Holder for next emote allowed time
+	var/mob/living/simple_animal/animal		//Animal owner
+
+
+
+/datum/belly/simple/New()
+	..()
+	animal = owner
+
+// @Override
+/datum/belly/simple/get_examine_msg(t_He, t_his, t_him, t_has, t_is)
+	if (internal_contents.len)
+		return "[t_He] [t_has] something solid inside [t_his] body!\n"
+
+// @Override
+/datum/belly/simple/toggle_digestion()
+	digest_mode = (digest_mode == DM_DIGEST) ? DM_HOLD : DM_DIGEST
+	animal << "<span class='notice'>You will [digest_mode == DM_DIGEST ? "now" : "no longer"] digest people inside you.</span>"
+
+// @Override
+/datum/belly/simple/process_Life()
+	for (var/mob/living/M in internal_contents)
+
+		if (animal.stat != DEAD && digest_mode == DM_DIGEST && M.digestable) //What to do if being digested
+			if (iscarbon(M) || isanimal(M))
+
+
+				if (world.time > emoteAfter) //Mob belly messages to people inside about digesting
+					var/message = pick(animal.stomach_emotes_d)
+					M << "<span class='alert'>[message]</span>"
+					emoteAfter = world.time + animal.gurgleTime
+
+
+				if(M.stat == DEAD && !animal.digest_emotes)
+					var/digest_alert = rand(1,6) // Update this based on the highest emote below
+					switch(digest_alert)
+						if(1)
+							animal << "<span class='notice'>You feel [M]'s body succumb to your digestive system, which breaks it apart into soft slurry.</span>"
+							M << "<span class='notice'>Your body succumbs to [animal]'s digestive system, which breaks you apart into soft slurry.</span>"
+						if(2)
+							animal << "<span class='notice'>You hear a lewd glorp as your insides grind [M] into a warm pulp.</span>"
+							M << "<span class='notice'>[animal]'s stomach lets out a lewd glorp as their insides grind you into a warm pulp.</span>"
+						if(3)
+							animal << "<span class='notice'>Your insides let out a rumble as it melts [M] into more of yourself.</span>"
+							M << "<span class='notice'>[animal]'s insides let out a rumble as it melts you into more of [animal].</span>"
+						if(4)
+							animal << "<span class='notice'>You feel a soft gurgle as [M]'s body loses form inside you. They're nothing but a soft mass of churning slop now.</span>"
+							M << "<span class='notice'>[animal] feels a soft gurgle as your body loses form. You're nothing but a soft mass of churning slop now.</span>"
+						if(5)
+							animal << "<span class='notice'>Your stomach groans as [M] falls apart into a thick soup. You can feel their remains soon flowing deeper into your body to be absorbed.</span>"
+							M << "<span class='notice'>[animal]'s stomach groans as you fall apart into a thick soup. Your remains soon flow deeper into [animal]'s body to be absorbed.</span>"
+						if(6)
+							animal << "<span class='notice'>Your gut kneads on every fiber of [M], softening them down into mush to fuel your next hunt.</span>"
+							M << "<span class='notice'>[animal]'s gut kneads on every fiber of your body, softening you down into mush to fuel their next hunt.</span>"
+					animal.nutrition += 20 // so eating dead mobs gives you *something*.
+					digestion_death(M)
+					continue
+
+				else if(M.stat == DEAD && animal.digest_emotes)	// Pred has a custom digestion message set. Pred message is 1, prey message is 2
+					animal << animal.digest_emotes["Pred"]
+					M << animal.digest_emotes["Prey"]
+					animal.nutrition += 20
+					digestion_death(M)
+					continue
+
+				// Deal digestion damage (and feed the pred)
+				if(air_master.current_cycle%3==1)
+					if(!(M.status_flags & GODMODE))
+						M.adjustBruteLoss(2)
+						M.adjustFireLoss(3)
+						var/difference = animal.playerscale / M.playerscale 	// LOOK HOW FUCKING CLEVER I AM.
+						animal.nutrition += 10/difference 					// I AM SO PROUD OF MYSELF. -Ace 	 PROUD OF YOU -NW.
+
+		else //Can't digest contents of the stomach, so we do the below.
+			if (world.time > emoteAfter)
+				var/message = pick(animal.stomach_emotes)
+				M << "<span class='notice'>[message]</span>"
+				emoteAfter = world.time + animal.gurgleTime
+
+
+
+// @Override
+/datum/belly/simple/relay_struggle(var/mob/user, var/direction)
+	if (!(user in internal_contents))
+		return  // User is not in this belly!
+
+	if(prob(40))
+		var/struggle_outer_message
+		var/struggle_user_message
+		var/stomach_noun = pick("stomach","gut","tummy","belly") // To randomize the word for 'stomach'
+
+		switch(rand(1,8)) // Increase this number per emote.
+			if(1)
+				struggle_outer_message = "<span class='alert'>[animal]'s [stomach_noun] wobbles with a squirming meal.</span>"
+				struggle_user_message = "<span class='alert'>You squirm inside of [animal]'s [stomach_noun], making it wobble around.</span>"
+			if(2)
+				struggle_outer_message = "<span class='alert'>[animal]'s [stomach_noun] jostles with movement.</span>"
+				struggle_user_message = "<span class='alert'>You jostle [animal]'s [stomach_noun] with movement.</span>"
+			if(3)
+				struggle_outer_message = "<span class='alert'>[animal]'s [stomach_noun] briefly swells outward as someone pushes from inside.</span>"
+				struggle_user_message = "<span class='alert'>You shove against the walls of [animal]'s [stomach_noun], making it briefly swell outward.</span>"
+			if(4)
+				struggle_outer_message = "<span class='alert'>[animal]'s [stomach_noun] fidgets with a trapped victim.</span>"
+				struggle_user_message = "<span class='alert'>You fidget around inside of [animal]'s [stomach_noun].</span>"
+			if(5)
+				struggle_outer_message = "<span class='alert'>[animal]'s [stomach_noun] jiggles with motion from inside.</span>"
+				struggle_user_message = "<span class='alert'>Your motion causes [animal]'s [stomach_noun] to jiggle.</span>"
+			if(6)
+				struggle_outer_message = "<span class='alert'>[animal]'s [stomach_noun] sloshes around.</span>"
+				struggle_user_message = "<span class='alert'>Your movement only causes [animal]'s [stomach_noun] to slosh around you.</span>"
+			if(7)
+				struggle_outer_message = "<span class='alert'>[animal]'s [stomach_noun] gushes softly.</span>"
+				struggle_user_message = "<span class='alert'>Your struggles only cause [animal]'s [stomach_noun] to gush softly around you.</span>"
+			if(8)
+				struggle_outer_message = "<span class='alert'>[animal]'s [stomach_noun] lets out a wet squelch.</span>"
+				struggle_user_message = "<span class='alert'>Your useless squirming only causes [animal]'s slimy [stomach_noun] to squelch over your body.</span>"
+
+		for(var/mob/M in hearers(4, animal))
+			M.show_message(struggle_outer_message, 2) // hearable
+		user << struggle_user_message
+
+		switch(rand(1,4))
+			if(1)
+				playsound(user.loc, 'sound/vore/squish1.ogg', 50, 1)
+			if(2)
+				playsound(user.loc, 'sound/vore/squish2.ogg', 50, 1)
+			if(3)
+				playsound(user.loc, 'sound/vore/squish3.ogg', 50, 1)
+			if(4)
+				playsound(user.loc, 'sound/vore/squish4.ogg', 50, 1)

--- a/code/modules/vore/belly/belly_stomach.dm
+++ b/code/modules/vore/belly/belly_stomach.dm
@@ -68,7 +68,7 @@
 									M << "<span class='notice'>[owner]'s stomach begins gushing your remains through their system, adding some extra weight to [owner]'s tits.</span>"
 						if(6)
 							owner << "<span class='notice'>Your stomach groans as [M] falls apart into a thick soup. You can feel their remains soon flowing deeper into your body to be absorbed.</span>"
-							M << "<span class='notice'>[owner]'s stomach groans as you falls apart into a thick soup. Your remains soon flow deeper into [owner]'s body to be absorbed.</span>"
+							M << "<span class='notice'>[owner]'s stomach groans as you fall apart into a thick soup. Your remains soon flow deeper into [owner]'s body to be absorbed.</span>"
 						if(7)
 							owner << "<span class='notice'>Your gut kneads on every fiber of [M], softening them down into mush to fuel your next hunt.</span>"
 							M << "<span class='notice'>[owner]'s gut kneads on every fiber of your body, softening you down into mush to fuel their next hunt.</span>"


### PR DESCRIPTION
Lots of changes.

-Gave simple_animal mobs their own 'simple' belly type that sends messages
to prey, in lieu of having an actual RP partner.

-Defined 48 or so emotes to be used for this purpose and added comment
blocks for people to add the rest that I wasn't creative enough to do.

-Rebalanced how fox and cat hunt. They were a bit 'homing missile' in the
past, they are a bit easier now.

-OOC escaping from a mob adds you to be excluded from being re-eaten for 5
seconds.

-Mobs now respect the no-digesting flag, and use the same vore bellies as
everyone else.

-Added custom emotes for Renault and Runtime to emote into their bellies
when they have prey. Go get ate!

-Refactored OOC escape code to clean up belly listings inside the pred and
just use the belly functions to get out.

-Split OOC escape message into two, depending on mob/PC escaping from, and
made admin message reflect this.

-Moved 'digestable' up to /mob/living so that practically everthing can
have that flag that's alive.