### PR TITLE
Make Xenobotany Machines Deconstructable

### DIFF
--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -42,7 +42,6 @@
 	var/obj/item/seeds/seed // Currently loaded seed packet.
 	var/obj/item/weapon/disk/botany/loaded_disk //Currently loaded data disk.
 
-	var/open = 0
 	var/active = 0
 	var/action_time = 5
 	var/last_action = 0
@@ -94,15 +93,14 @@
 			user << "You load [W] into [src]."
 		return
 
-	if(istype(W,/obj/item/weapon/screwdriver))
-		open = !open
-		user << "<span class='notice'>You [open ? "open" : "close"] the maintenance panel.</span>"
+	if(default_deconstruction_screwdriver(user, W))
 		return
 
-	if(open)
-		if(istype(W, /obj/item/weapon/crowbar))
-			dismantle()
-			return
+	if(default_deconstruction_crowbar(user, W))
+		return
+
+	if(default_part_replacement(user, W))
+		return
 
 	if(istype(W,/obj/item/weapon/disk/botany))
 		if(loaded_disk)
@@ -135,6 +133,16 @@
 
 	var/datum/seed/genetics // Currently scanned seed genetic structure.
 	var/degradation = 0     // Increments with each scan, stops allowing gene mods after a certain point.
+
+/obj/machinery/botany/extractor/New()
+	..()
+	component_parts = list()
+	component_parts += new /obj/item/weapon/circuitboard/extractor(null)
+	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/weapon/stock_parts/matter_bin(null)
+	component_parts += new /obj/item/weapon/stock_parts/manipulator(null)
+	component_parts += new /obj/item/weapon/stock_parts/manipulator(null)
+	RefreshParts()
 
 /obj/machinery/botany/extractor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 
@@ -266,6 +274,16 @@
 	name = "bioballistic delivery system"
 	icon_state = "traitgun"
 	disk_needs_genes = 1
+
+/obj/machinery/botany/editor/New()
+	..()
+	component_parts = list()
+	component_parts += new /obj/item/weapon/circuitboard/editor(null)
+	component_parts += new /obj/item/weapon/stock_parts/micro_laser(null)
+	component_parts += new /obj/item/weapon/stock_parts/manipulator(null)
+	component_parts += new /obj/item/weapon/stock_parts/manipulator(null)
+	component_parts += new /obj/item/weapon/stock_parts/manipulator(null)
+	RefreshParts()
 
 /obj/machinery/botany/editor/ui_interact(mob/user, ui_key = "main", var/datum/nanoui/ui = null, var/force_open = 1)
 


### PR DESCRIPTION
Previous update (Fixing #42) made these machines constructable.  Even
better that they be deconstructable as well!

To this end I added the parts to the contents in the constructors.
I also noticed it was using outdated code to handle opening the panel and deconstructing, so I upgraded to use the new machinery default methods.