### PR TITLE
Airtank status on hardsuit interface

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -412,6 +412,9 @@
 	data["maxcharge"] =    cell ? cell.maxcharge : 0
 	data["chargestatus"] = cell ? Floor((cell.charge/cell.maxcharge)*50) : 0
 
+	data["tankPressure"] = air_supply ? round(air_supply.air_contents.return_pressure() ? air_supply.air_contents.return_pressure() : 0) : 0
+	data["relPressure"] =  air_supply ? round(air_supply.distribute_pressure ? air_supply.distribute_pressure : 0) : 0
+
 	data["emagged"] =       subverted
 	data["coverlock"] =     locked
 	data["interfacelock"] = interface_locked

--- a/nano/templates/hardsuit.tmpl
+++ b/nano/templates/hardsuit.tmpl
@@ -56,6 +56,14 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 					{{:helper.displayBar(data.chargestatus, 0, 50, (data.chargestatus >= 35) ? 'good' : (data.chargestatus >= 15) ? 'average' : 'bad')}} {{:data.charge}}/{{:data.maxcharge}}
 				</div>
 			</div>
+			<div class='inlineBlock extraTopPadding'>
+				<div class='fixedLeft boldText'>
+					Air supply
+				</div>
+				<div>
+					{{:helper.displayBar(data.tankPressure, 0, 1013, (data.tankPressure > 200) ? 'good' : ((data.tankPressure > 100) ? 'average' : 'bad'))}} {{:data.tankPressure}} kPa ({{:data.relPressure}} kPa)
+				</div>
+			</div>
 			<div>
 				<div class='inlineBlock extraTopPadding'>
 					<div class='fixedLeft boldText'>


### PR DESCRIPTION
Adds a bar displaying pressure, plus the specified release pressure in
parenthesis after the actual kPa pressure value.

Fixes #139