### PR TITLE
Rwalls will no longer be melted by fires.

### DIFF
--- a/code/game/turfs/simulated/walls_reinforced.dm
+++ b/code/game/turfs/simulated/walls_reinforced.dm
@@ -6,7 +6,7 @@
 	density = 1
 
 	damage_cap = 800
-	max_temperature = 6000
+	max_temperature = INFINITY
 
 	walltype = "rwall"
 


### PR DESCRIPTION
I ded pls nerf.

Also, I personally don't think Rwalls should be breached by fire, it makes toxins unfun.

Points to consider:
Toxins fires render the entire department unusable.

Canisters can handle any temperature and any pressure up to several billion degrees.

Fire suits are rated to 30,000 degrees.