### PR TITLE
PDA able to fit in ear slot

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -9,7 +9,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 	icon = 'icons/obj/pda.dmi'
 	icon_state = "pda"
 	item_state = "electronic"
-	w_class = 2.0
+	w_class = 1.0
 	slot_flags = SLOT_ID | SLOT_BELT
 
 	//Main variables


### PR DESCRIPTION
Lowered PDA's weight class to tiny, making it able to fit in the ear slot like it did with the old code. Is probably implantable now too, which also makes sense.

Thread: http://forum.vore-station.net/viewtopic.php?f=20&t=458