### PR TITLE
Sergal Language Hotfix

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -227,7 +227,7 @@
 	desc = "The common galactic tongue."
 	speech_verb = "says"
 	whisper_verb = "whispers"
-	key = "0"
+	key = "c"
 	flags = RESTRICTED
 	syllables = list("blah","blah","blah","bleh","meh","neh","nah","wah")
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -294,7 +294,7 @@
 	syllables = list ("gra","ba","ba","breh","bra","rah","dur","ra","ro","gro","go","ber","bar","geh","heh", "gra")
 
 /datum/language/sergal
-	name = "Sâgaru"
+	name = "Sagaru"
 	desc = "The dominant language of the Sergal homeworld, Vilous. It consists of aggressive low-pitched hissing and throaty growling."
 	speech_verb = "snarls"
 	colour = "sergal"

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -255,7 +255,7 @@
 	name_plural = "sergals"
 	icobase = 'icons/mob/human_races/r_sergal.dmi'
 	deform = 'icons/mob/human_races/r_def_sergal.dmi'
-	language = "Sâgaru"
+	language = "Sagaru"
 	tail = "sergtail"
 	primitive = /mob/living/carbon/monkey/sergal
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)


### PR DESCRIPTION
Fixes the Sergal from losing it's language due to an error with a character in the language name causing it to automatically change when the file is touched.

Also allows galactic common to be used by races that normally don't start with it by using :c , as opposed to the :0 command which was broken.

Fixes issue #340 