### PR TITLE
Handcuffs grab fix

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -31,7 +31,7 @@
 
 		//check for an aggressive grab
 		for (var/obj/item/weapon/grab/G in C.grabbed_by)
-			if (G.loc == user && G.state >= GRAB_AGGRESSIVE)
+			if (G.loc == user && G.state >= GRAB_PASSIVE)
 				place_handcuffs(C, user)
 				return
 		user << "\red You need to have a firm grip on [C] before you can put \the [src] on!"

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -679,7 +679,7 @@ It can still be worn/put on as normal.
 				//check that we are still grabbing them
 				var/grabbing = 0
 				for (var/obj/item/weapon/grab/G in target.grabbed_by)
-					if (G.loc == source && G.state >= GRAB_AGGRESSIVE)
+					if (G.loc == source && G.state >= GRAB_PASSIVE)
 						grabbing = 1
 						break
 				if (!grabbing)


### PR DESCRIPTION
Makes it so handcuffs only need a passive grab, as opposed to a aggressive  grab.

Fixes issue #309 