### PR TITLE
Makes inside flavor text save. V2

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -164,10 +164,10 @@
 	S["flavor_texts_feet"]		>> flavor_texts["feet"]
 
 	//Inside flavour text
-	S["inside_flavour_texts_stomach"]	>> inside_flavour_texts["stomach"]
-	S["inside_flavour_texts_balls"]		>> inside_flavour_texts["balls"]
-	S["inside_flavour_texts_womb"]		>> inside_flavour_texts["womb"]
-	S["inside_flavour_texts_boobs"]		>> inside_flavour_texts["boobs"]
+	S["inside_flavour_texts_stomach"]	>> inside_flavour_texts["Stomach"]
+	S["inside_flavour_texts_balls"]		>> inside_flavour_texts["Cock]
+	S["inside_flavour_texts_womb"]		>> inside_flavour_texts["Womb"]
+	S["inside_flavour_texts_boobs"]		>> inside_flavour_texts["Boob"]
 
 	//Flavour text for robots.
 	S["flavour_texts_robot_Default"] >> flavour_texts_robot["Default"]


### PR DESCRIPTION
This fix enables inside flavor text to actually save. Fully tested and working. 
No bugs were present during the test. Fixes issue #348 

Reposting this since github decided it'd be a /great/ idea to automatically switch a branch I was working on to this branch, so it totally screwed it up. Fixed now, and it shouldn't happen again.