### PR TITLE
Made slime race clonable.

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -369,7 +369,7 @@
 
 
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/slime_glomp)
-	flags = CAN_JOIN | NO_SCAN | NO_SLIP | NO_BREATHE | HAS_EYE_COLOR | HAS_SKIN_COLOR
+	flags = CAN_JOIN | NO_SLIP | NO_BREATHE | HAS_EYE_COLOR | HAS_SKIN_COLOR
 	darksight = 3
 
 	blood_color = "#05FF9B"


### PR DESCRIPTION
Removed the NO_SCAN flag by popular demand.

http://forum.vore-station.net/viewtopic.php?f=20&t=470

In the future we will remove it, but give slime people another means of IC revivial (e.g. injecting core, xenobio cloner). However, those more preferable options will take time to code so, this is just a hold-over.