### PR TITLE
Slime beards and slime reagent flag

### DIFF
--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -396,3 +396,4 @@
 
 	breath_type = null //no breathing?
 //	poison_type = null //no poison?
+	reagent_tag = IS_SLIMEP

--- a/code/modules/mob/new_player/sprite_accessories.dm
+++ b/code/modules/mob/new_player/sprite_accessories.dm
@@ -496,7 +496,7 @@
 
 	icon = 'icons/mob/Human_face.dmi'
 	gender = MALE // barf (unless you're a dorf, dorfs dig chix /w beards :P)
-	species_allowed = list("Human")
+	species_allowed = list("Human", "Slime Person")
 
 	shaved
 		name = "Shaved"
@@ -602,7 +602,7 @@
 		name = "Unathi Horns"
 		icon_state = "soghun_horns"
 		species_allowed = list("Unathi")
-		
+
 	una_hood
 		name = "Cobra Hood"
 		icon_state = "soghun_hood"

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -710,6 +710,7 @@ var/list/be_special_flags = list(
 #define IS_SKRELL 3
 #define IS_UNATHI 4
 #define IS_XENOS  5
+#define IS_SLIMEP  6
 
 #define MAX_GEAR_COST 5 // Used in chargen for accessory loadout limit.
 


### PR DESCRIPTION
Male Slime people can now have beards (presumably slime beards).

Also added a flag for on_mob_life procs exclusive to slime people. (on_mob_life is used for metabolizing, I think). This provides a means to check if someone is a slime person during metabolism of chemicals and such. Could be useful if we want slime persons to have different reactions to chemicals.