### PR TITLE
Warns admins when vending machines are fiddled with.

### DIFF
--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -35,6 +35,8 @@ var/const/VENDING_WIRE_IDSCAN = 8
 		if(VENDING_WIRE_CONTRABAND)
 			V.categories ^= CAT_HIDDEN
 		if(VENDING_WIRE_ELECTRIFY)
+			log_game("\blue [key_name_admin(usr)] electrified a vending machine.")
+			message_admins("[key_name_admin(user)] opened electrified a vending machine at [loc.loc.name] ([loc.x],[loc.y],[loc.z]), ")
 			V.seconds_electrified = 30
 		if(VENDING_WIRE_IDSCAN)
 			V.scan_id = !V.scan_id

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -35,8 +35,8 @@ var/const/VENDING_WIRE_IDSCAN = 8
 		if(VENDING_WIRE_CONTRABAND)
 			V.categories ^= CAT_HIDDEN
 		if(VENDING_WIRE_ELECTRIFY)
-			log_game("\blue [key_name_admin(usr)] electrified a vending machine.")
-			message_admins("[key_name_admin(user)] opened electrified a vending machine at [loc.loc.name] ([loc.x],[loc.y],[loc.z]), ")
+			log_game("\blue [usr.key] [key_name(usr)] electrified a vending machine.")
+			message_admins("[usr.key] [key_name(usr)] opened electrified a vending machine at [loc.loc.name] ([loc.x],[loc.y],[loc.z]), ")
 			V.seconds_electrified = 30
 		if(VENDING_WIRE_IDSCAN)
 			V.scan_id = !V.scan_id

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -35,8 +35,8 @@ var/const/VENDING_WIRE_IDSCAN = 8
 		if(VENDING_WIRE_CONTRABAND)
 			V.categories ^= CAT_HIDDEN
 		if(VENDING_WIRE_ELECTRIFY)
-			log_game("\blue [usr.key] [key_name(usr)] electrified a vending machine.")
-			message_admins("[usr.key] [key_name(usr)] opened electrified a vending machine at [loc.loc.name] ([loc.x],[loc.y],[loc.z]), ")
+			log_game("\blue [usr.key] [key_name(usr)] electrified a vending machine with a multitool.")
+			message_admins("[usr.key] [key_name(usr)] electrified a vending machine with a multitool.")
 			V.seconds_electrified = 30
 		if(VENDING_WIRE_IDSCAN)
 			V.scan_id = !V.scan_id
@@ -50,8 +50,12 @@ var/const/VENDING_WIRE_IDSCAN = 8
 			V.categories &= ~CAT_HIDDEN  
 		if(VENDING_WIRE_ELECTRIFY)
 			if(mended)
+				log_game("\blue [usr.key] [key_name(usr)] may have electrified a vending machine.")
+				message_admins("[usr.key] [key_name(usr)] may have electrified a vending machine.")
 				V.seconds_electrified = 0
 			else
+				log_game("\blue [usr.key] [key_name(usr)] may have electrified a vending machine.")
+				message_admins("[usr.key] [key_name(usr)] may have electrified a vending machine.")
 				V.seconds_electrified = -1
 		if(VENDING_WIRE_IDSCAN)
 			V.scan_id = 1

--- a/code/datums/wires/vending.dm
+++ b/code/datums/wires/vending.dm
@@ -50,12 +50,12 @@ var/const/VENDING_WIRE_IDSCAN = 8
 			V.categories &= ~CAT_HIDDEN  
 		if(VENDING_WIRE_ELECTRIFY)
 			if(mended)
-				log_game("\blue [usr.key] [key_name(usr)] may have electrified a vending machine.")
-				message_admins("[usr.key] [key_name(usr)] may have electrified a vending machine.")
+				log_game("\blue [usr.key] [key_name(usr)] has mended an electrified a vending machine.")
+				message_admins("[usr.key] [key_name(usr)] has mended an electrified a vending machine.")
 				V.seconds_electrified = 0
 			else
-				log_game("\blue [usr.key] [key_name(usr)] may have electrified a vending machine.")
-				message_admins("[usr.key] [key_name(usr)] may have electrified a vending machine.")
+				log_game("\blue [usr.key] [key_name(usr)] has electrified a vending machine.")
+				message_admins("[usr.key] [key_name(usr)] has electrified a vending machine.")
 				V.seconds_electrified = -1
 		if(VENDING_WIRE_IDSCAN)
 			V.scan_id = 1

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -214,6 +214,8 @@
 		return
 	else if(istype(W, /obj/item/weapon/screwdriver))
 		src.panel_open = !src.panel_open
+		log_game("\blue [key_name_admin(usr)] used a screwdriver on a vending machine.")
+		message_admins("[usr.key] [key_name(usr)] used a screwdriver on a vending machine at [loc.loc.name] ([loc.x],[loc.y],[loc.z]), ")
 		user << "You [src.panel_open ? "open" : "close"] the maintenance panel."
 		src.overlays.Cut()
 		if(src.panel_open)
@@ -222,6 +224,8 @@
 		nanomanager.update_uis(src)  // Speaker switch is on the main UI, not wires UI
 		return
 	else if(istype(W, /obj/item/device/multitool)||istype(W, /obj/item/weapon/wirecutters))
+		log_game("\blue [usr.key] [key_name(usr)] used wirectuters on a vending machine.")
+		message_admins("[usr.key] [key_name(usr)] used wirecutters on a vending machine at [loc.loc.name] ([loc.x],[loc.y],[loc.z]), ")
 		if(src.panel_open)
 			attack_hand(user)
 		return

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -224,8 +224,8 @@
 		nanomanager.update_uis(src)  // Speaker switch is on the main UI, not wires UI
 		return
 	else if(istype(W, /obj/item/device/multitool)||istype(W, /obj/item/weapon/wirecutters))
-		log_game("\blue [usr.key] [key_name(usr)] used wirectuters on a vending machine.")
-		message_admins("[usr.key] [key_name(usr)] used wirecutters on a vending machine.")
+		log_game("\blue [usr.key] [key_name(usr)] used wirectuters/multitool on a vending machine.")
+		message_admins("[usr.key] [key_name(usr)] used wirecutters/multitool on a vending machine.")
 		if(src.panel_open)
 			attack_hand(user)
 		return

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -214,8 +214,8 @@
 		return
 	else if(istype(W, /obj/item/weapon/screwdriver))
 		src.panel_open = !src.panel_open
-		log_game("\blue [key_name_admin(usr)] used a screwdriver on a vending machine.")
-		message_admins("[usr.key] [key_name(usr)] used a screwdriver on a vending machine at [loc.loc.name] ([loc.x],[loc.y],[loc.z]), ")
+		log_game("\blue [usr.key] [key_name(usr)] used a screwdriver on a vending machine.")
+		message_admins("[usr.key] [key_name(usr)] used a screwdriver on a vending machine.")
 		user << "You [src.panel_open ? "open" : "close"] the maintenance panel."
 		src.overlays.Cut()
 		if(src.panel_open)
@@ -225,7 +225,7 @@
 		return
 	else if(istype(W, /obj/item/device/multitool)||istype(W, /obj/item/weapon/wirecutters))
 		log_game("\blue [usr.key] [key_name(usr)] used wirectuters on a vending machine.")
-		message_admins("[usr.key] [key_name(usr)] used wirecutters on a vending machine at [loc.loc.name] ([loc.x],[loc.y],[loc.z]), ")
+		message_admins("[usr.key] [key_name(usr)] used wirecutters on a vending machine.")
 		if(src.panel_open)
 			attack_hand(user)
 		return

--- a/code/game/machinery/vending.dm
+++ b/code/game/machinery/vending.dm
@@ -224,8 +224,8 @@
 		nanomanager.update_uis(src)  // Speaker switch is on the main UI, not wires UI
 		return
 	else if(istype(W, /obj/item/device/multitool)||istype(W, /obj/item/weapon/wirecutters))
-		log_game("\blue [usr.key] [key_name(usr)] used wirectuters/multitool on a vending machine.")
-		message_admins("[usr.key] [key_name(usr)] used wirecutters/multitool on a vending machine.")
+		log_game("\blue [usr.key] [key_name(usr)] used wirectuters on a vending machine.")
+		message_admins("[usr.key] [key_name(usr)] used wirecutters on a vending machine.")
 		if(src.panel_open)
 			attack_hand(user)
 		return


### PR DESCRIPTION
Fixes issue #389 by making it so it'll show up in admin logs and warn admins when a player:
Uses a screwdriver on a vending machine
Uses wirecutters on a vending machine
Uses a multitool on a vending machine
Electrifies a vending machines
Mends/fixes an electrified vending machine.