### PR TITLE
Adds nudity permit (jumpsuit) and mankini.

### DIFF
--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -417,6 +417,12 @@ var/global/list/gear_datums = list()
 
 // Uniform slot
 
+/datum/gear/permit
+	display_name = "nudity permit (jumpsuit)"
+	path = /obj/item/clothing/under/permit
+	slot = slot_w_uniform
+	cost = 1
+
 /datum/gear/blazer_blue
 	display_name = "blazer, blue"
 	path = /obj/item/clothing/under/blazer
@@ -1328,3 +1334,4 @@ var/global/list/gear_datums = list()
 	cost = 1
 	sort_category = "ears"
 	whitelisted = "Skrell"
+

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -422,6 +422,12 @@ var/global/list/gear_datums = list()
 	path = /obj/item/clothing/under/permit
 	slot = slot_w_uniform
 	cost = 1
+	
+/datum/gear/mankini
+	display_name = "mankini (jumpsuit)"
+	path = /obj/item/clothing/under/stripper/mankini
+	slot = slot_w_uniform
+	cost = 1
 
 /datum/gear/blazer_blue
 	display_name = "blazer, blue"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -515,3 +515,11 @@
 	desc = "When Spetznaz on scene, objective no longer save hostage."
 	icon_state = "russobluecamo"
 	item_color = "russobluecamo"
+	
+/obj/item/clothing/under/permit
+	name = "public nudity permit"
+	desc = "This permit entitles the bearer to conduct their duties without a uniform. Normally issued to furred crewmembers or those with nothing to hide"
+	icon = 'icons/obj/paper.dmi'
+	icon_state = "paper"
+	item_state = "golem"
+	item_color = "golem"

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -518,7 +518,7 @@
 	
 /obj/item/clothing/under/permit
 	name = "public nudity permit"
-	desc = "This permit entitles the bearer to conduct their duties without a uniform. Normally issued to furred crewmembers or those with nothing to hide"
+	desc = "This permit entitles the bearer to conduct their duties without a uniform. Normally issued to furred crewmembers or those with nothing to hide."
 	icon = 'icons/obj/paper.dmi'
 	icon_state = "paper"
 	item_state = "golem"


### PR DESCRIPTION
Adds a nudity permit (select able "jumpsuit" that allows players to have all the abilities of a normal jumpsuit, but without the jumpsuit sprite.) and also a mankini, which used to be only obtainable by hacking the clothing vendor.