### PR TITLE
Adds xenoarcheology cyborgs.

### DIFF
--- a/code/global.dm
+++ b/code/global.dm
@@ -228,7 +228,8 @@ var/list/cheartstopper = list("potassium_chloride")                       // Thi
 // Used by robots and robot preferences.
 var/list/robot_module_types = list(
 	"Standard", "Engineering", "Construction", "Surgeon",  "Crisis",
-	"Miner",    "Janitor",     "Service",      "Clerical", "Security"
+	"Miner",    "Janitor",     "Service",      "Clerical", "Security",
+	"Xenoarch"
 )
 
 // Some scary sounds.

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -350,6 +350,12 @@ var/list/robot_verbs_default = list(
 			module_sprites["Destroyer Droid"] = "droid-combat"
 			module_sprites["Mister Gutsy"] = "mrgutsy"
 			module.channels = list("Security" = 1)
+			
+		if("Xenoarch")
+			module = new /obj/item/weapon/robot_module/xenoarch(src)
+			module_sprites["Basic"] = "landmate" //These sprites will do
+			module_sprites["Basic - Treaded"] = "engiborg+tread" //And so will these.
+			module.channels = list("Science" = 1) //Give em science comms, why not.
 
 	//languages
 	module.add_languages(src)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -353,8 +353,8 @@ var/list/robot_verbs_default = list(
 			
 		if("Xenoarch")
 			module = new /obj/item/weapon/robot_module/xenoarch(src)
-			module_sprites["Basic"] = "landmate" //These sprites will do
-			module_sprites["Basic - Treaded"] = "engiborg+tread" //And so will these.
+			module_sprites["Basic"] = "droid-miner" //These sprites will do
+			module_sprites["Drone"] = "drone-miner" //And so will these.
 			module.channels = list("Science" = 1) //Give em science comms, why not.
 
 	//languages

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -448,6 +448,7 @@
 	src.modules += new /obj/item/device/flashlight(src)
 	src.modules += new /obj/item/device/gps(src)
 	src.modules += new /obj/item/device/ano_scanner(src)
+	src.modules += new /obj/item/weapon/card/id/science //So they can use the field generator.
 	return
 
 /obj/item/weapon/robot_module/drone

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -448,7 +448,6 @@
 	src.modules += new /obj/item/device/flashlight(src)
 	src.modules += new /obj/item/device/gps(src)
 	src.modules += new /obj/item/device/ano_scanner(src)
-	src.modules += new /obj/item/weapon/card/id/science //So they can use the field generator.
 	return
 
 /obj/item/weapon/robot_module/drone

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -448,6 +448,7 @@
 	src.modules += new /obj/item/device/flashlight(src)
 	src.modules += new /obj/item/device/gps(src)
 	src.modules += new /obj/item/device/ano_scanner(src)
+	src.modules += new /obj/item/weapon/pickaxe/borgdrill(src)
 	return
 
 /obj/item/weapon/robot_module/drone

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -286,20 +286,20 @@
 	else
 		T.charge_tick = 0
 
-	/obj/item/weapon/robot_module/janitor
-		name = "janitorial robot module"
-	
-	/obj/item/weapon/robot_module/janitor/New()
-		..()
-		src.modules += new /obj/item/device/flash(src)
-		src.modules += new /obj/item/weapon/soap/nanotrasen(src)
-		src.modules += new /obj/item/weapon/storage/bag/trash(src)
-		src.modules += new /obj/item/weapon/mop(src)
-		src.modules += new /obj/item/device/lightreplacer(src)
-		src.emag = new /obj/item/weapon/reagent_containers/spray(src)
-		src.emag.reagents.add_reagent("lube", 250)
-		src.emag.name = "Lube spray"
-		return
+/obj/item/weapon/robot_module/janitor
+	name = "janitorial robot module"
+
+/obj/item/weapon/robot_module/janitor/New()
+	..()
+	src.modules += new /obj/item/device/flash(src)
+	src.modules += new /obj/item/weapon/soap/nanotrasen(src)
+	src.modules += new /obj/item/weapon/storage/bag/trash(src)
+	src.modules += new /obj/item/weapon/mop(src)
+	src.modules += new /obj/item/device/lightreplacer(src)
+	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
+	src.emag.reagents.add_reagent("lube", 250)
+	src.emag.name = "Lube spray"
+	return
 
 /obj/item/weapon/robot_module/janitor/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/device/lightreplacer/LR = locate() in src.modules
@@ -433,7 +433,7 @@
 	src.modules += new /obj/item/borg/combat/mobility(src)
 	src.emag = new /obj/item/weapon/gun/energy/lasercannon/mounted(src)
 	return
-	
+
 /obj/item/weapon/robot_module/xenoarch
 	name = "xenoarch robot module"
 

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -286,20 +286,20 @@
 	else
 		T.charge_tick = 0
 
-/obj/item/weapon/robot_module/janitor
-	name = "janitorial robot module"
-
-/obj/item/weapon/robot_module/janitor/New()
-	..()
-	src.modules += new /obj/item/device/flash(src)
-	src.modules += new /obj/item/weapon/soap/nanotrasen(src)
-	src.modules += new /obj/item/weapon/storage/bag/trash(src)
-	src.modules += new /obj/item/weapon/mop(src)
-	src.modules += new /obj/item/device/lightreplacer(src)
-	src.emag = new /obj/item/weapon/reagent_containers/spray(src)
-	src.emag.reagents.add_reagent("lube", 250)
-	src.emag.name = "Lube spray"
-	return
+	/obj/item/weapon/robot_module/janitor
+		name = "janitorial robot module"
+	
+	/obj/item/weapon/robot_module/janitor/New()
+		..()
+		src.modules += new /obj/item/device/flash(src)
+		src.modules += new /obj/item/weapon/soap/nanotrasen(src)
+		src.modules += new /obj/item/weapon/storage/bag/trash(src)
+		src.modules += new /obj/item/weapon/mop(src)
+		src.modules += new /obj/item/device/lightreplacer(src)
+		src.emag = new /obj/item/weapon/reagent_containers/spray(src)
+		src.emag.reagents.add_reagent("lube", 250)
+		src.emag.name = "Lube spray"
+		return
 
 /obj/item/weapon/robot_module/janitor/respawn_consumable(var/mob/living/silicon/robot/R, var/amount)
 	var/obj/item/device/lightreplacer/LR = locate() in src.modules
@@ -432,6 +432,22 @@
 	src.modules += new /obj/item/borg/combat/shield(src)
 	src.modules += new /obj/item/borg/combat/mobility(src)
 	src.emag = new /obj/item/weapon/gun/energy/lasercannon/mounted(src)
+	return
+	
+/obj/item/weapon/robot_module/xenoarch
+	name = "xenoarch robot module"
+
+/obj/item/weapon/robot_module/xenoarch/New()
+	..()
+	src.modules += new /obj/item/weapon/pickaxe/excavationdrill(src)
+	src.modules += new /obj/item/borg/sight/meson(src)
+	src.modules += new /obj/item/device/beacon_locator(src)
+	src.modules += new /obj/item/device/measuring_tape(src)
+	src.modules += new /obj/item/device/depth_scanner(src)
+	src.modules += new /obj/item/weapon/wrench(src)
+	src.modules += new /obj/item/device/flashlight(src)
+	src.modules += new /obj/item/device/gps(src)
+	src.modules += new /obj/item/device/ano_scanner(src)
 	return
 
 /obj/item/weapon/robot_module/drone


### PR DESCRIPTION
Adds a xenoarch cyborg that is able to aide in xenoarcheology. 
It is meant to only help, and not be able to do the entirety of xenoarcheology and anomaly research.

**Features**:
Has all needed tools to do xenoarcheology excavation.
Is able to mine out anomalies with no errors, and no required human interaction.
Uses the xenoarcheology specialized drill, instead of the normal xenoarcheology pick set.
Has science radio comms.

**Comments**:
Requires a human to do anomaly research
Requires a human to initially swipe their ID on the suspension generator if the cyborg will be going after artifacts, and not just anomalies.

**Notes**:
Uses the sciency looking mining cyborg sprite and or the mining drone sprite. Depends on which one the user desires/selects.

