### PR TITLE
Allows races to use galactic common.

### DIFF
--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -227,7 +227,7 @@
 	desc = "The common galactic tongue."
 	speech_verb = "says"
 	whisper_verb = "whispers"
-	key = "c"
+	key = "6"
 	flags = RESTRICTED
 	syllables = list("blah","blah","blah","bleh","meh","neh","nah","wah")
 


### PR DESCRIPTION
Due to a bug, aka :c already being used for the command channel, you couldn't use galactic common manually. Now you can.