### PR TITLE
Adds restriction to creating web bindings. (Urgent HOTFIX)

### DIFF
--- a/code/modules/vore/spiderTaurPowers.dm
+++ b/code/modules/vore/spiderTaurPowers.dm
@@ -21,14 +21,22 @@ obj/item/clothing/suit/web_bindings
 mob/proc/weaveWeb()
 	set name = "Weave Web"
 	set category = "Species Powers"
-	src.visible_message("\blue \the [src] weaves a web from their spinneret silk.")
-	spawn(30) //3 seconds to form
+	if(nutrition >= 30) //BUGS!
+		src.visible_message("\blue \the [src] weaves a web from their spinneret silk.")
+		nutrition -= 30 //Squash the bugs!
+		spawn(30) //3 seconds to form
 		new /obj/effect/spider/stickyweb(src.loc)
+	else
+		src << "You do not have enough nutrition to create webbing!"
 
 mob/proc/weaveWebBindings()
 	set name = "Weave Web Bindings"
 	set category = "Species Powers"
-	src.visible_message("\blue \the [src] pulls silk from their spinneret and delicately weaves it into bindings.")
-	spawn(30) //5 seconds to weave the bindings~
-		var/obj/item/clothing/suit/web_bindings/bindings = new()
-		src.put_in_hands(bindings)
+	if(nutrition >= 30) //Due to the restrictions of this being a direct proc, I can't put on a time delay.
+		src.visible_message("\blue \the [src] pulls silk from their spinneret and delicately weaves it into bindings.")
+		nutrition -= 30 //So don't abuse this or you'll make the coders cry and raise the nutirition needed.
+		spawn(30) //5 seconds to weave the bindings~
+			var/obj/item/clothing/suit/web_bindings/bindings = new() //This sprite is amazing, I must say.
+			src.put_in_hands(bindings)
+	else
+		src << "You do not have enough nutrition to create webbing!" //CK~

--- a/code/modules/vore/voretype/tail.dm
+++ b/code/modules/vore/voretype/tail.dm
@@ -13,7 +13,7 @@
 	return perform_the_nom(user, prey, pred, attempt_msg, success_msg, 'sound/vore/insert.ogg')
 
 /datum/voretype/tail/feed_self_to_grabbed(var/mob/living/carbon/human/user, var/vore/pred_capable/pred)
-	var/attempt_msg = "<span class='danger'>[user] is attempting to stuff theif self into [pred]'s tail!</span>"
+	var/attempt_msg = "<span class='danger'>[user] is attempting to stuff their self into [pred]'s tail!</span>"
 	var/success_msg = "<span class='danger'>[user] stuffs their self fully into [pred]'s tail!</span>"
 
 	return perform_the_nom(user, user, pred, attempt_msg, success_msg, 'sound/vore/insert.ogg')


### PR DESCRIPTION
Adds a nutrition restriction to web bindings.
Nutrition restriction is 30 units needed. It isn't a lot, but can be changed to be higher if need be.

Without the restriction, you could easily spawn in thousands of web tiles, causing massive lag.


Note: Also fixes a typo in tail vore.