### PR TITLE
Being barefoot no longer slows. Lowered Taj bonus movespeed (reasons inside)

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -90,7 +90,7 @@
 	var/siemens_coefficient = 1   // The lower, the thicker the skin and better the insulation.
 	var/darksight = 2             // Native darksight distance.
 	var/flags = 0                 // Various specific features.
-	var/slowdown = 0              // Passive movement speed malus (or boost, if negative)
+	var/slowdown = -1              // Passive movement speed malus (or boost, if negative)
 	var/primitive                 // Lesser form, if any (ie. monkey for humans)
 	var/gluttonous                // Can eat some mobs. 1 for monkeys, 2 for people.
 	var/equip_problems			  // Problems with equipment types for this species.

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -69,7 +69,7 @@
 	primitive = /mob/living/carbon/monkey/tajara
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	darksight = 8
-	slowdown = -1
+	slowdown = -1.5
 	burn_mod = 1.2
 
 	blurb = "The Tajaran race is a species of feline-like bipeds hailing from the planet of Ahdomai in the \
@@ -397,14 +397,14 @@
 	breath_type = null //no breathing?
 //	poison_type = null //no poison?
 	reagent_tag = IS_SLIMEP
-	
+
 /datum/species/nevrean
 	name = "Nevrean" //Basically, just a new sprite. No upsides and no downsides, other than a new language.
 	name_plural = "Nevreans"
 	icobase = 'icons/mob/human_races/r_nevrean.dmi'
 	deform = 'icons/mob/human_races/r_def_nevrean.dmi'
 	language = "Birdsong" //New language. Birdsong.
-	tail = "nevrean" 
+	tail = "nevrean"
 	primitive = /mob/living/carbon/monkey/sparra
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 

--- a/code/modules/mob/living/carbon/human/species/station/station.dm
+++ b/code/modules/mob/living/carbon/human/species/station/station.dm
@@ -69,7 +69,7 @@
 	primitive = /mob/living/carbon/monkey/tajara
 	unarmed_types = list(/datum/unarmed_attack/stomp, /datum/unarmed_attack/kick, /datum/unarmed_attack/claws, /datum/unarmed_attack/bite/sharp)
 	darksight = 8
-	slowdown = -1.5
+	//slowdown = -1 By ace's request, removed bonus movespeed from taj -Antsnap
 	burn_mod = 1.2
 
 	blurb = "The Tajaran race is a species of feline-like bipeds hailing from the planet of Ahdomai in the \

--- a/code/setup.dm
+++ b/code/setup.dm
@@ -148,7 +148,9 @@
 #define NORMPIPERATE             30   // Pipe-insulation rate divisor.
 #define HEATPIPERATE             8    // Heat-exchange pipe insulation.
 #define FLOWFRAC                 0.99 // Fraction of gas transfered per process.
-#define SHOES_SLOWDOWN          -1.0  // How much shoes slow you down by default. Negative values speed you up.
+#define SHOES_SLOWDOWN           0  // How much shoes slow you down by default. Negative values speed you up.
+//EDIT: Used to be -1. Removing barefoot speed penelty is impossible cause it doesn't exist, so instead we increase every species' runspeed by 1
+//I.e. set their slowdown to -1
 
 // Item inventory slot bitmasks.
 #define SLOT_OCLOTHING  1


### PR DESCRIPTION
https://github.com/SpadesNeil/VOREstation/issues/404


So shoes actually applied a negative slowdown (aka a speedup). I removed this shoe speedup in order to make barefooted people move the same as shoed. However, this would make everyone slower than they currently are, so I had to change default species slowdown to the negative slowdown that shoes used to give.

Tajarans previously had a slowdown of -1, which would be equivalent to -2 now. However, the reason for this was (probably) because many Taj characters would also be barefoot cause paws and stuff. Since that reason is obsolete now that barefoot chars are no longer slowed, I lowered their speedboost by half.

I'd be in favor or removing taj speedboost all together for balance (so everyone has equal speed now). But, people might complain, and I guess it makes sense for cat people to move quicker cause, cats. 