### PR TITLE
Make daemon language color blood red instead of black.

### DIFF
--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -83,7 +83,7 @@ h1.alert, h2.alert		{color: #000000;}
 /* Languages */
 
 
-.demonishc				{color: #CC0044;}
+.daemonc				{color: #990033;}
 .birdsongc				{color: #FFBBFF;}
 .alien					{color: #543354;}
 .tajaran				{color: #803B56;}


### PR DESCRIPTION
It shouldn't have been black. That was a bug.

The color is now: 990033

It's noticably different than the ingame color for blood, in case anyone could get confused from it. But, still keeps the theme nicely I think :3