### PR TITLE
Secure crates can be made tamper proof now

### DIFF
--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -9,6 +9,7 @@
 	var/attempts = 10
 	var/codelen = 4
 	locked = 1
+	tamper_proof = 1
 
 /obj/structure/closet/crate/secure/loot/New()
 	..()


### PR DESCRIPTION
This will deter players from abusing projectiles to open boxes, as there
is now a chance to destroy the contents and cause a (small) fire, or a
small explosion that will alert security.

Crates will not detonate if unlocked so the CE doesn't have their life
made hell for using an emitter to unlock the supermatter core.