### PR TITLE
Allows borgs to digest people. Notified admins when they do so.

### DIFF
--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -191,7 +191,7 @@
 	var/inject_amount = 10
 	var/min_health = -100
 	var/occupied = 0
-	var/list/injection_chems = list("dexalin", "bicaridine", "kelotane","anti_toxin", "alkysine", "imidazoline", "spaceacillin", "paracetamol", "digestive_enzyme") //The borg is able to heal every damage type. As a nerf, they use 750 charge per injection.
+	var/list/injection_chems = list("dexalin", "bicaridine", "kelotane","anti_toxin", "alkysine", "imidazoline", "spaceacillin", "paracetamol", "digestive_enzymes") //The borg is able to heal every damage type. As a nerf, they use 750 charge per injection.
 
 /obj/item/weapon/dogborg/sleeper/Exit(atom/movable/O)
 	return 0
@@ -386,4 +386,4 @@
 	inject_amount = 10
 	min_health = -100
 	occupied = 0
-	injection_chems = list("digestive_enzyme") //So they don't have all the same chems as the medihound!
+	injection_chems = list("digestive_enzymes") //So they don't have all the same chems as the medihound!

--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -343,7 +343,7 @@
 				R << "<span class='notice'>You don't have enough power to synthesise fluids.</span>"
 				return
 			else if(patient.reagents.get_reagent_amount(chem) + 10 >= 20) //Preventing people from accidentally killing theirselves by trying to inject too many chemicals!
-				R << "<span class='notice'>Occupant is currently immersed in [units] unit\s of [chemical_reagents_list[chem]]. Your stomach is currently too full of fluids to secrete more.</span>"
+				R << "<span class='notice'>Your stomach is currently too full of fluids to secrete more fluids of this kind.</span>"
 			else if(patient.reagents.get_reagent_amount(chem) + 10 <= 20) //No overdoses for you
 				patient.reagents.add_reagent(chem, inject_amount)
 				R.cell.charge = R.cell.charge - 750 //-750 charge per injection
@@ -352,6 +352,7 @@
 	if(patient && patient.stat = DEAD)
 		var/confirm = alert(src, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
 		if(confirm == "Okay")
+			var/mob/living/silicon/robot.R = user
 			R << "<span class='notice'>You feel your stomach slowly churn around [patient], breaking them down into a soft slurry to be used as power for your systems.</span>"
 			patient << "<span class='notice'>You feel [R]'s stomach slowly churn around your form, breaking you down into a soft slurry to be used as power for [R]'s systems.</span>"
 			del(patient)

--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -333,7 +333,7 @@
 			usr << "<span class='notice'>ERROR: Subject is not in stable condition for auto-injection.</span>"
 			
 	else if(patient && patient.stat == DEAD) //This is so they can digest someone that is dead
-		var/confirm = alert(src, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
+		var/confirm = alert(usr, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
 		if(confirm == "Okay")
 			var/mob/living/silicon/robot.R = usr
 			R << "<span class='notice'>You feel your stomach slowly churn around [patient], breaking them down into a soft slurry to be used as power for your systems.</span>"
@@ -360,7 +360,7 @@
 			var/units = round(patient.reagents.get_reagent_amount(chem))
 			R << "<span class='notice'>Occupant is currently immersed in [units] unit\s of [chemical_reagents_list[chem]].</span>"
 	if(patient && patient.stat == DEAD) //So is this. If they inject a dead person, this pops up.
-		var/confirm = alert(src, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
+		var/confirm = alert(user, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
 		if(confirm == "Okay")
 			var/mob/living/silicon/robot.R = user
 			R << "<span class='notice'>You feel your stomach slowly churn around [patient], breaking them down into a soft slurry to be used as power for your systems.</span>"

--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -332,10 +332,10 @@
 		else
 			usr << "<span class='notice'>ERROR: Subject is not in stable condition for auto-injection.</span>"
 			
-	else if(patient && patient.stat == DEAD)
+	else if(patient && patient.stat == DEAD) //This is so they can digest someone that is dead
 		var/confirm = alert(src, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
 		if(confirm == "Okay")
-			var/mob/living/silicon/robot.R = user
+			var/mob/living/silicon/robot.R = usr
 			R << "<span class='notice'>You feel your stomach slowly churn around [patient], breaking them down into a soft slurry to be used as power for your systems.</span>"
 			patient << "<span class='notice'>You feel [R]'s stomach slowly churn around your form, breaking you down into a soft slurry to be used as power for [R]'s systems.</span>"
 			del(patient)
@@ -359,7 +359,7 @@
 				R.cell.charge = R.cell.charge - 750 //-750 charge per injection
 			var/units = round(patient.reagents.get_reagent_amount(chem))
 			R << "<span class='notice'>Occupant is currently immersed in [units] unit\s of [chemical_reagents_list[chem]].</span>"
-	if(patient && patient.stat == DEAD)
+	if(patient && patient.stat == DEAD) //So is this. If they inject a dead person, this pops up.
 		var/confirm = alert(src, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
 		if(confirm == "Okay")
 			var/mob/living/silicon/robot.R = user

--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -331,6 +331,16 @@
 			inject_chem(usr, href_list["inject"])
 		else
 			usr << "<span class='notice'>ERROR: Subject is not in stable condition for auto-injection.</span>"
+			
+	else if(patient && patient.stat == DEAD)
+		var/confirm = alert(src, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
+		if(confirm == "Okay")
+			var/mob/living/silicon/robot.R = user
+			R << "<span class='notice'>You feel your stomach slowly churn around [patient], breaking them down into a soft slurry to be used as power for your systems.</span>"
+			patient << "<span class='notice'>You feel [R]'s stomach slowly churn around your form, breaking you down into a soft slurry to be used as power for [R]'s systems.</span>"
+			del(patient)
+			message_admins("[key_name(R)] digested [patient]([R ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[R.x];Y=[R.y];Z=[R.z]'>JMP</a>" : "null"])")
+			R.cell.charge = R.cell.charge + 30000 //As much as a hyper battery. You /are/ digesting an entire person, after all!
 	else
 		usr << "<span class='notice'>ERROR: Subject cannot metabolise chemicals.</span>"
 	updateUsrDialog()

--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -141,10 +141,6 @@
 				R.cell.charge = R.cell.charge + (C.maxcharge / 3)
 				del(target)
 			return
-<<<<<<< HEAD
-		var/obj/item/I = target
-=======
->>>>>>> origin/master
 		user.visible_message("[user] begins to lick \the [target.name] clean...", "<span class='notice'>You begin to lick \the [target.name] clean...</span>")
 		if(do_after (user, 50))
 			user << "<span class='notice'>You clean \the [target.name].</span>"

--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -331,15 +331,15 @@
 			inject_chem(usr, href_list["inject"])
 		else
 			usr << "<span class='notice'>ERROR: Subject is not in stable condition for auto-injection.</span>"
-			
+
 	else if(patient && patient.stat == DEAD) //This is so they can digest someone that is dead
 		var/confirm = alert(usr, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
 		if(confirm == "Okay")
 			var/mob/living/silicon/robot.R = usr
+			message_admins("[key_name(R)] digested [patient]([R ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[R.x];Y=[R.y];Z=[R.z]'>JMP</a>" : "null"])")
 			R << "<span class='notice'>You feel your stomach slowly churn around [patient], breaking them down into a soft slurry to be used as power for your systems.</span>"
 			patient << "<span class='notice'>You feel [R]'s stomach slowly churn around your form, breaking you down into a soft slurry to be used as power for [R]'s systems.</span>"
 			del(patient)
-			message_admins("[key_name(R)] digested [patient]([R ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[R.x];Y=[R.y];Z=[R.z]'>JMP</a>" : "null"])")
 			R.cell.charge = R.cell.charge + 30000 //As much as a hyper battery. You /are/ digesting an entire person, after all!
 	else
 		usr << "<span class='notice'>ERROR: Subject cannot metabolise chemicals.</span>"
@@ -363,12 +363,12 @@
 		var/confirm = alert(user, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
 		if(confirm == "Okay")
 			var/mob/living/silicon/robot.R = user
+			message_admins("[key_name(R)] digested [patient]([R ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[R.x];Y=[R.y];Z=[R.z]'>JMP</a>" : "null"])")
 			R << "<span class='notice'>You feel your stomach slowly churn around [patient], breaking them down into a soft slurry to be used as power for your systems.</span>"
 			patient << "<span class='notice'>You feel [R]'s stomach slowly churn around your form, breaking you down into a soft slurry to be used as power for [R]'s systems.</span>"
 			del(patient)
-			message_admins("[key_name(R)] digested [patient]([R ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[R.x];Y=[R.y];Z=[R.z]'>JMP</a>" : "null"])")
 			R.cell.charge = R.cell.charge + 30000 //As much as a hyper battery. You /are/ digesting an entire person, after all!
-			
+
 /obj/item/weapon/dogborg/sleeper/process()
 	if(src.occupied == 0)
 		processing_objects.Remove(src)

--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -191,7 +191,7 @@
 	var/inject_amount = 10
 	var/min_health = -100
 	var/occupied = 0
-	var/list/injection_chems = list("dexalin", "bicaridine", "kelotane","anti_toxin", "alkysine", "imidazoline", "spaceacillin", "paracetamol") //The borg is able to heal every damage type. As a nerf, they use 750 charge per injection.
+	var/list/injection_chems = list("dexalin", "bicaridine", "kelotane","anti_toxin", "alkysine", "imidazoline", "spaceacillin", "paracetamol", "digestive_enzyme") //The borg is able to heal every damage type. As a nerf, they use 750 charge per injection.
 
 /obj/item/weapon/dogborg/sleeper/Exit(atom/movable/O)
 	return 0
@@ -383,7 +383,7 @@
 	desc = "Equipment for a K9 unit. A mounted portable-brig that holds criminals."
 	icon = 'icons/mob/dogborg.dmi'
 	icon_state = "sleeper"
-	inject_amount = 0
+	inject_amount = 10
 	min_health = -100
 	occupied = 0
-	injection_chems = list("water") //So they don't have all the same chems as the medihound!
+	injection_chems = list("digestive_enzyme") //So they don't have all the same chems as the medihound!

--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -349,7 +349,7 @@
 				R.cell.charge = R.cell.charge - 750 //-750 charge per injection
 			var/units = round(patient.reagents.get_reagent_amount(chem))
 			R << "<span class='notice'>Occupant is currently immersed in [units] unit\s of [chemical_reagents_list[chem]].</span>"
-	if(patient && patient.stat = DEAD)
+	if(patient && patient.stat == DEAD)
 		var/confirm = alert(src, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
 		if(confirm == "Okay")
 			var/mob/living/silicon/robot.R = user

--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -355,6 +355,7 @@
 			R << "<span class='notice'>You feel your stomach slowly churn around [patient], breaking them down into a soft slurry to be used as power for your systems.</span>"
 			patient << "<span class='notice'>You feel [R]'s stomach slowly churn around your form, breaking you down into a soft slurry to be used as power for [R]'s systems.</span>"
 			del(patient)
+			message_admins("[key_name(R)] digested [patient]([R ? "<a href='?_src_=holder;adminplayerobservecoodjump=1;X=[R.x];Y=[R.y];Z=[R.z]'>JMP</a>" : "null"])")
 			R.cell.charge = R.cell.charge + 30000 //As much as a hyper battery. You /are/ digesting an entire person, after all!
 			
 /obj/item/weapon/dogborg/sleeper/process()

--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -244,7 +244,7 @@
 
 /obj/item/weapon/dogborg/sleeper/proc/drain()
 	var/mob/living/silicon/robot.R = hound
-	R.cell.charge = R.cell.charge - 10
+	R.cell.charge = R.cell.charge - 5
 
 /obj/item/weapon/dogborg/sleeper/attack_self(mob/user)
 	if(..())

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3227,6 +3227,20 @@ datum
 				if(M.confused !=0) M.confused = max(0,M.confused - 5)
 				..()
 				return
+				
+				
+		digestive_enzymes
+			name = "Digestive Enzymes"
+			id = "digestive_enzymes"
+			description = "Digestive enzymes are one of the most corrosive fluids known in the universe. Rapidly breaks down and digests anything it comes in contact with."
+			reagent_state = LIQUID
+			color = "#673910" // rgb: 103, 57, 16
+
+			on_mob_life(var/mob/living/M as mob)
+				if(!M) M = holder.my_atom
+				M.adjustFireLoss(3) // 3 burn per tick. About as much as digestion.
+				..()
+				return
 
 //////////////////////////////////////////////The ten friggen million reagents that get you drunk//////////////////////////////////////////////
 

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3227,7 +3227,6 @@ datum
 			glass_name = "glass of The Doctor's Delight"
 			glass_desc = "A healthy mixture of juices, guaranteed to keep you healthy until the next toolboxing takes place."
 			glass_center_of_mass = list("x"=16, "y"=8)
-			
 			on_mob_life(var/mob/living/M as mob)
 				M:nutrition += nutriment_factor
 				holder.remove_reagent(src.id, FOOD_METABOLISM)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3221,7 +3221,6 @@ datum
 			description = "A gulp a day keeps the MediBot away. That's probably for the best."
 			reagent_state = LIQUID
 			color = "#FF8CFF" // rgb: 255, 140, 255
-
 			nutriment_factor = 1 * FOOD_METABOLISM
 
 			glass_icon_state = "doctorsdelightglass"

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3240,8 +3240,6 @@ datum
 				if(M.confused !=0) M.confused = max(0,M.confused - 5)
 				..()
 				return
-				
-				
 //////////////////////////////////////////////The ten friggen million reagents that get you drunk//////////////////////////////////////////////
 
 		atomicbomb

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3208,7 +3208,6 @@ datum
 			glass_name = "glass of Rewriter"
 			glass_desc = "The secret of the sanctuary of the Libarian..."
 			glass_center_of_mass = list("x"=16, "y"=9)
-
 			on_mob_life(var/mob/living/M as mob)
 				..()
 				M.make_jittery(5)
@@ -3222,7 +3221,6 @@ datum
 			reagent_state = LIQUID
 			color = "#FF8CFF" // rgb: 255, 140, 255
 			nutriment_factor = 1 * FOOD_METABOLISM
-
 			glass_icon_state = "doctorsdelightglass"
 			glass_name = "glass of The Doctor's Delight"
 			glass_desc = "A healthy mixture of juices, guaranteed to keep you healthy until the next toolboxing takes place."

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3208,6 +3208,7 @@ datum
 			glass_name = "glass of Rewriter"
 			glass_desc = "The secret of the sanctuary of the Libarian..."
 			glass_center_of_mass = list("x"=16, "y"=9)
+
 			on_mob_life(var/mob/living/M as mob)
 				..()
 				M.make_jittery(5)
@@ -3220,11 +3221,14 @@ datum
 			description = "A gulp a day keeps the MediBot away. That's probably for the best."
 			reagent_state = LIQUID
 			color = "#FF8CFF" // rgb: 255, 140, 255
+
 			nutriment_factor = 1 * FOOD_METABOLISM
+
 			glass_icon_state = "doctorsdelightglass"
 			glass_name = "glass of The Doctor's Delight"
 			glass_desc = "A healthy mixture of juices, guaranteed to keep you healthy until the next toolboxing takes place."
 			glass_center_of_mass = list("x"=16, "y"=8)
+
 			on_mob_life(var/mob/living/M as mob)
 				M:nutrition += nutriment_factor
 				holder.remove_reagent(src.id, FOOD_METABOLISM)
@@ -3237,6 +3241,7 @@ datum
 				if(M.confused !=0) M.confused = max(0,M.confused - 5)
 				..()
 				return
+
 //////////////////////////////////////////////The ten friggen million reagents that get you drunk//////////////////////////////////////////////
 
 		atomicbomb

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -3227,7 +3227,7 @@ datum
 			glass_name = "glass of The Doctor's Delight"
 			glass_desc = "A healthy mixture of juices, guaranteed to keep you healthy until the next toolboxing takes place."
 			glass_center_of_mass = list("x"=16, "y"=8)
-
+			
 			on_mob_life(var/mob/living/M as mob)
 				M:nutrition += nutriment_factor
 				holder.remove_reagent(src.id, FOOD_METABOLISM)

--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -2651,6 +2651,19 @@ datum
 				M.nutrition += nutriment_factor
 				..()
 				return
+				
+		digestive_enzymes
+			name = "Digestive Enzymes"
+			id = "digestive_enzymes"
+			description = "Digestive enzymes are one of the most corrosive fluids known in the universe. Rapidly breaks down and digests anything it comes in contact with."
+			reagent_state = LIQUID
+			color = "#673910" // rgb: 103, 57, 16
+
+			on_mob_life(var/mob/living/M as mob)
+				if(!M) M = holder.my_atom
+				M.adjustFireLoss(3) // 3 burn per tick. About as much as digestion.
+				..()
+				return
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////// DRINKS BELOW, Beer is up there though, along with cola. Cap'n Pete's Cuban Spiced Rum////////////////////////////////
@@ -3229,19 +3242,6 @@ datum
 				return
 				
 				
-		digestive_enzymes
-			name = "Digestive Enzymes"
-			id = "digestive_enzymes"
-			description = "Digestive enzymes are one of the most corrosive fluids known in the universe. Rapidly breaks down and digests anything it comes in contact with."
-			reagent_state = LIQUID
-			color = "#673910" // rgb: 103, 57, 16
-
-			on_mob_life(var/mob/living/M as mob)
-				if(!M) M = holder.my_atom
-				M.adjustFireLoss(3) // 3 burn per tick. About as much as digestion.
-				..()
-				return
-
 //////////////////////////////////////////////The ten friggen million reagents that get you drunk//////////////////////////////////////////////
 
 		atomicbomb


### PR DESCRIPTION
Exactly what it says on the title.
Allows borgs to inject "digestive enzymes" into people which does 3 burn damage per tick.
After they die, if the borgs try to inject them with any chemical again, it gives  them a text box, asking if  they'd like to digest the dead person. If  they do so, it'll tell admins and give the borg 30000 charge (As much as a hyper battery)

Also, ignore the last 5 commits at the bottom. There were a few red and  green lines I was trying to fix from showing up in the files list, as I didn't mean to remove them, and I ended up taking a few  tries. Woo.

Also prevents borgs from killing theirselves when trying to inject someone when they're already at the max chemical limit.

Note: Also makes the sleeper take away less power. It was removing power so fast that scenes were insanely hard to do without constantly recharging.