### PR TITLE
Fix 'replacetext' and add AI boards.

### DIFF
--- a/code/ZAS/Variable Settings.dm
+++ b/code/ZAS/Variable Settings.dm
@@ -348,7 +348,7 @@ var/global/vs_control/vsc = new
 			var/txt = vars["[V]_RANDOM"]
 			if(findtextEx(txt,"PROB"))
 				txt = text2list(txt,"/")
-				txt[1] = replacetext(txt[1],"PROB","")
+				txt[1] = bayreplacetext(txt[1],"PROB","")
 				var/p = text2num(txt[1])
 				var/r = txt[2]
 				if(prob(p))
@@ -356,7 +356,7 @@ var/global/vs_control/vsc = new
 				else
 					newvalue = vars[V]
 			else if(findtextEx(txt,"PICK"))
-				txt = replacetext(txt,"PICK","")
+				txt = bayreplacetext(txt,"PICK","")
 				txt = text2list(txt,",")
 				newvalue = pick(txt)
 			else

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -36,7 +36,7 @@
 //Removes a few problematic characters
 /proc/sanitize_simple(var/t,var/list/repl_chars = list("\n"="#","\t"="#"))
 	for(var/char in repl_chars)
-		t = replacetext(t, char, repl_chars[char])
+		t = bayreplacetext(t, char, repl_chars[char])
 	return t
 
 /proc/readd_quotes(var/t)
@@ -203,10 +203,11 @@ proc/checkhtml(var/t)
 /*
  * Text modification
  */
-/proc/replacetext(text, find, replacement)
+
+/proc/bayreplacetext(text, find, replacement)
 	return list2text(text2list(text, find), replacement)
 
-/proc/replacetextEx(text, find, replacement)
+/proc/bayreplacetextEx(text, find, replacement)
 	return list2text(text2listEx(text, find), replacement)
 
 //Adds 'u' number of zeros ahead of the text 't'

--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -875,7 +875,7 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 						corner.density = 1
 						corner.anchored = 1
 						corner.icon = X.icon
-						corner.icon_state = replacetext(X.icon_state, "_s", "_f")
+						corner.icon_state = bayreplacetext(X.icon_state, "_s", "_f")
 						corner.tag = "delete me"
 						corner.name = "wall"
 
@@ -895,7 +895,7 @@ proc/anim(turf/location as turf,target as mob|obj,a_icon,a_icon_state as text,fl
 						// Reset the shuttle corners
 						if(O.tag == "delete me")
 							X.icon = 'icons/turf/shuttle.dmi'
-							X.icon_state = replacetext(O.icon_state, "_f", "_s") // revert the turf to the old icon_state
+							X.icon_state = bayreplacetext(O.icon_state, "_f", "_s") // revert the turf to the old icon_state
 							X.name = "wall"
 							del(O) // prevents multiple shuttle corners from stacking
 							continue
@@ -1348,7 +1348,7 @@ var/list/WALLITEMS = list(
 	return 0
 
 /proc/format_text(text)
-	return replacetext(replacetext(text,"\proper ",""),"\improper ","")
+	return bayreplacetext(bayreplacetext(text,"\proper ",""),"\improper ","")
 
 /proc/topic_link(var/datum/D, var/arglist, var/content)
 	if(istype(arglist,/list))

--- a/code/datums/spell.dm
+++ b/code/datums/spell.dm
@@ -101,7 +101,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 			if(prob(50))//Auto-mute? Fuck that noise
 				usr.say(invocation)
 			else
-				usr.say(replacetext(invocation," ","`"))
+				usr.say(bayreplacetext(invocation," ","`"))
 			if(usr.gender==MALE)
 				playsound(usr.loc, pick('sound/misc/null.ogg','sound/misc/null.ogg'), 100, 1)
 			else
@@ -110,7 +110,7 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 			if(prob(50))
 				usr.whisper(invocation)
 			else
-				usr.whisper(replacetext(invocation," ","`"))
+				usr.whisper(bayreplacetext(invocation," ","`"))
 
 /obj/effect/proc_holder/spell/New()
 	..()

--- a/code/defines/obj.dm
+++ b/code/defines/obj.dm
@@ -160,8 +160,8 @@
 			even = !even
 
 	dat += "</table>"
-	dat = replacetext(dat, "\n", "") // so it can be placed on paper correctly
-	dat = replacetext(dat, "\t", "")
+	dat = bayreplacetext(dat, "\n", "") // so it can be placed on paper correctly
+	dat = bayreplacetext(dat, "\t", "")
 	return dat
 
 

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -52,7 +52,7 @@
 	name_part1 = pick("the Automatic ", "Farmer ", "Lord ", "Professor ", "the Cuban ", "the Evil ", "the Dread King ", "the Space ", "Lord ", "the Great ", "Duke ", "General ")
 	name_part2 = pick("Melonoid", "Murdertron", "Sorcerer", "Ruin", "Jeff", "Ectoplasm", "Crushulon", "Uhangoid", "Vhakoid", "Peteoid", "slime", "Griefer", "ERPer", "Lizard Man", "Unicorn")
 
-	src.enemy_name = replacetext((name_part1 + name_part2), "the ", "")
+	src.enemy_name = bayreplacetext((name_part1 + name_part2), "the ", "")
 	src.name = (name_action + name_part1 + name_part2)
 
 

--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -24,7 +24,7 @@
 	var/list/formatted = list()
 	for(var/job in jobs)
 		formatted.Add(list(list(
-			"display_name" = replacetext(job, " ", "&nbsp"),
+			"display_name" = bayreplacetext(job, " ", "&nbsp"),
 			"target_rank" = get_target_rank(),
 			"job" = job)))
 
@@ -108,7 +108,7 @@
 		var/list/all_centcom_access = list()
 		for(var/access in get_all_centcom_access())
 			all_centcom_access.Add(list(list(
-				"desc" = replacetext(get_centcom_access_desc(access), " ", "&nbsp"),
+				"desc" = bayreplacetext(get_centcom_access_desc(access), " ", "&nbsp"),
 				"ref" = access,
 				"allowed" = (access in modify.access) ? 1 : 0)))
 
@@ -120,7 +120,7 @@
 			for(var/access in get_region_accesses(i))
 				if (get_access_desc(access))
 					accesses.Add(list(list(
-						"desc" = replacetext(get_access_desc(access), " ", "&nbsp"),
+						"desc" = bayreplacetext(get_access_desc(access), " ", "&nbsp"),
 						"ref" = access,
 						"allowed" = (access in modify.access) ? 1 : 0)))
 

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -100,7 +100,7 @@
 
 /obj/machinery/computer/proc/decode(text)
 	// Adds line breaks
-	text = replacetext(text, "\n", "<BR>")
+	text = bayreplacetext(text, "\n", "<BR>")
 	return text
 
 

--- a/code/game/machinery/computer/supply.dm
+++ b/code/game/machinery/computer/supply.dm
@@ -107,7 +107,7 @@
 		reqform.info += "RANK: [idrank]<br>"
 		reqform.info += "REASON: [reason]<br>"
 		reqform.info += "SUPPLY CRATE TYPE: [P.name]<br>"
-		reqform.info += "ACCESS RESTRICTION: [replacetext(get_access_desc(P.access))]<br>"
+		reqform.info += "ACCESS RESTRICTION: [bayreplacetext(get_access_desc(P.access))]<br>"
 		reqform.info += "CONTENTS:<br>"
 		reqform.info += P.manifest
 		reqform.info += "<hr>"
@@ -311,7 +311,7 @@
 		reqform.info += "RANK: [idrank]<br>"
 		reqform.info += "REASON: [reason]<br>"
 		reqform.info += "SUPPLY CRATE TYPE: [P.name]<br>"
-		reqform.info += "ACCESS RESTRICTION: [replacetext(get_access_desc(P.access))]<br>"
+		reqform.info += "ACCESS RESTRICTION: [bayreplacetext(get_access_desc(P.access))]<br>"
 		reqform.info += "CONTENTS:<br>"
 		reqform.info += P.manifest
 		reqform.info += "<hr>"

--- a/code/game/machinery/computer3/computers/arcade.dm
+++ b/code/game/machinery/computer3/computers/arcade.dm
@@ -63,7 +63,7 @@
 	name_part1 = pick("the Automatic ", "Farmer ", "Lord ", "Professor ", "the Cuban ", "the Evil ", "the Dread King ", "the Space ", "Lord ", "the Great ", "Duke ", "General ")
 	name_part2 = pick("Melonoid", "Murdertron", "Sorcerer", "Ruin", "Jeff", "Ectoplasm", "Crushulon", "Uhangoid", "Vhakoid", "Peteoid", "slime", "Griefer", "ERPer", "Lizard Man", "Unicorn")
 
-	enemy_name = replacetext(name_part1, "the ", "") + name_part2
+	enemy_name = bayreplacetext(name_part1, "the ", "") + name_part2
 	name = (name_action + name_part1 + name_part2)
 
 

--- a/code/game/machinery/computer3/computers/card.dm
+++ b/code/game/machinery/computer3/computers/card.dm
@@ -46,7 +46,7 @@
 			if(counter >= 6)
 				jobs_all += "</tr><tr height='20'><td></td><td></td>"
 				counter = 0
-			jobs_all += "<td height='20' weight='100'><a href='?src=\ref[src];assign=[job]'>[replacetext(job, " ", "&nbsp")]</a></td>"
+			jobs_all += "<td height='20' weight='100'><a href='?src=\ref[src];assign=[job]'>[bayreplacetext(job, " ", "&nbsp")]</a></td>"
 
 		counter = 0
 		jobs_all += "</tr><tr><td><font color='#FFA500'><b>Engineering</b></font></td>"//Orange
@@ -55,7 +55,7 @@
 			if(counter >= 6)
 				jobs_all += "</tr><tr height='20'><td></td><td></td>"
 				counter = 0
-			jobs_all += "<td height='20' weight='100'><a href='?src=\ref[src];assign=[job]'>[replacetext(job, " ", "&nbsp")]</a></td>"
+			jobs_all += "<td height='20' weight='100'><a href='?src=\ref[src];assign=[job]'>[bayreplacetext(job, " ", "&nbsp")]</a></td>"
 
 		counter = 0
 		jobs_all += "</tr><tr height='20'><td><font color='#008000'><b>Medical</b></font></td>"//Green
@@ -64,7 +64,7 @@
 			if(counter >= 6)
 				jobs_all += "</tr><tr height='20'><td></td><td></td>"
 				counter = 0
-			jobs_all += "<td weight='100'><a href='?src=\ref[src];assign=[job]'>[replacetext(job, " ", "&nbsp")]</a></td>"
+			jobs_all += "<td weight='100'><a href='?src=\ref[src];assign=[job]'>[bayreplacetext(job, " ", "&nbsp")]</a></td>"
 
 		counter = 0
 		jobs_all += "</tr><tr height='20'><td><font color='#800080'><b>Science</b></font></td>"//Purple
@@ -73,7 +73,7 @@
 			if(counter >= 6)
 				jobs_all += "</tr><tr height='20'><td></td><td></td>"
 				counter = 0
-			jobs_all += "<td weight='100'><a href='?src=\ref[src];assign=[job]'>[replacetext(job, " ", "&nbsp")]</a></td>"
+			jobs_all += "<td weight='100'><a href='?src=\ref[src];assign=[job]'>[bayreplacetext(job, " ", "&nbsp")]</a></td>"
 
 		counter = 0
 		jobs_all += "</tr><tr height='20'><td><font color='#808080'><b>Civilian</b></font></td>"//Grey
@@ -82,7 +82,7 @@
 			if(counter >= 6)
 				jobs_all += "</tr><tr height='20'><td></td><td></td>"
 				counter = 0
-			jobs_all += "<td weight='100'><a href='?src=\ref[src];assign=[job]'>[replacetext(job, " ", "&nbsp")]</a></td>"
+			jobs_all += "<td weight='100'><a href='?src=\ref[src];assign=[job]'>[bayreplacetext(job, " ", "&nbsp")]</a></td>"
 
 			dat = {"<script type="text/javascript">
 								function markRed(){
@@ -124,9 +124,9 @@
 			accesses += "<td style='width:14%' valign='top'>"
 			for(var/A in get_region_accesses(i))
 				if(A in writer.access)
-					accesses += topic_link(src,"access=[A]","<font color='red'>[replacetext(get_access_desc(A), " ", "&nbsp")]</font>") + " "
+					accesses += topic_link(src,"access=[A]","<font color='red'>[bayreplacetext(get_access_desc(A), " ", "&nbsp")]</font>") + " "
 				else
-					accesses += topic_link(src,"access=[A]",replacetext(get_access_desc(A), " ", "&nbsp")) + " "
+					accesses += topic_link(src,"access=[A]",bayreplacetext(get_access_desc(A), " ", "&nbsp")) + " "
 				accesses += "<br>"
 			accesses += "</td>"
 		accesses += "</tr></table>"
@@ -336,9 +336,9 @@
 		var/accesses = "<h5>Central Command:</h5>"
 		for(var/A in get_all_centcom_access())
 			if(A in writer.access)
-				accesses += topic_link(src,"access=[A]","<font color='red'>[replacetext(get_centcom_access_desc(A), " ", "&nbsp")]</font>") + " "
+				accesses += topic_link(src,"access=[A]","<font color='red'>[bayreplacetext(get_centcom_access_desc(A), " ", "&nbsp")]</font>") + " "
 			else
-				accesses += topic_link(src,"access=[A]",replacetext(get_centcom_access_desc(A), " ", "&nbsp")) + " "
+				accesses += topic_link(src,"access=[A]",bayreplacetext(get_centcom_access_desc(A), " ", "&nbsp")) + " "
 		return accesses
 
 	authenticate()

--- a/code/game/machinery/computer3/program.dm
+++ b/code/game/machinery/computer3/program.dm
@@ -37,7 +37,7 @@ Programs are a file that can be executed
 
 /datum/file/program/proc/decode(text)
 		//adds line breaks
-		text = replacetext(text, "\n","<BR>")
+		text = bayreplacetext(text, "\n","<BR>")
 		return text
 
 

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -227,7 +227,7 @@ var/list/obj/machinery/requests_console/allConsoles = list()
 			dat += "[msg]<BR>"
 		var/obj/item/weapon/paper/R = new(src.loc)
 		R.name = "[department] Messages"
-		R.info = replacetext(dat, " href=", " nothref=") // Try and make links inoperative
+		R.info = bayreplacetext(dat, " href=", " nothref=") // Try and make links inoperative
 
 	if(reject_bad_text(href_list["write"]))
 		dpt = ckey(href_list["write"]) //write contains the string of the receiving department's name

--- a/code/game/machinery/telecomms/traffic_control.dm
+++ b/code/game/machinery/telecomms/traffic_control.dm
@@ -47,8 +47,8 @@
 
 			if(length(viewingcode))
 				// This piece of code is very important - it escapes quotation marks so string aren't cut off by the input element
-				var/showcode = replacetext(storedcode, "\\\"", "\\\\\"")
-				showcode = replacetext(storedcode, "\"", "\\\"")
+				var/showcode = bayreplacetext(storedcode, "\\\"", "\\\\\"")
+				showcode = bayreplacetext(storedcode, "\"", "\\\"")
 
 				for(var/mob/M in viewingcode)
 
@@ -171,8 +171,8 @@
 						winshow(editingcode, "Telecomms IDE", 1) // show the IDE
 						winset(editingcode, "tcscode", "is-disabled=false")
 						winset(editingcode, "tcscode", "text=\"\"")
-						var/showcode = replacetext(storedcode, "\\\"", "\\\\\"")
-						showcode = replacetext(storedcode, "\"", "\\\"")
+						var/showcode = bayreplacetext(storedcode, "\\\"", "\\\\\"")
+						showcode = bayreplacetext(storedcode, "\"", "\\\"")
 						winset(editingcode, "tcscode", "text=\"[showcode]\"")
 						spawn()
 							update_ide()
@@ -182,7 +182,7 @@
 						winshow(usr, "Telecomms IDE", 1) // show the IDE
 						winset(usr, "tcscode", "is-disabled=true")
 						winset(editingcode, "tcscode", "text=\"\"")
-						var/showcode = replacetext(storedcode, "\"", "\\\"")
+						var/showcode = bayreplacetext(storedcode, "\"", "\\\"")
 						winset(usr, "tcscode", "text=\"[showcode]\"")
 
 				if("togglerun")

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -170,19 +170,19 @@ move an amendment</a> to the drawing.</p>
 
 
 /obj/item/blueprints/proc/set_area_machinery_title(var/area/A,var/title,var/oldtitle)
-	if (!oldtitle) // or replacetext goes to infinite loop
+	if (!oldtitle) // or bayreplacetext goes to infinite loop
 		return
 	for(var/area/RA in A.related)
 		for(var/obj/machinery/alarm/M in RA)
-			M.name = replacetext(M.name,oldtitle,title)
+			M.name = bayreplacetext(M.name,oldtitle,title)
 		for(var/obj/machinery/power/apc/M in RA)
-			M.name = replacetext(M.name,oldtitle,title)
+			M.name = bayreplacetext(M.name,oldtitle,title)
 		for(var/obj/machinery/atmospherics/unary/vent_scrubber/M in RA)
-			M.name = replacetext(M.name,oldtitle,title)
+			M.name = bayreplacetext(M.name,oldtitle,title)
 		for(var/obj/machinery/atmospherics/unary/vent_pump/M in RA)
-			M.name = replacetext(M.name,oldtitle,title)
+			M.name = bayreplacetext(M.name,oldtitle,title)
 		for(var/obj/machinery/door/M in RA)
-			M.name = replacetext(M.name,oldtitle,title)
+			M.name = bayreplacetext(M.name,oldtitle,title)
 	//TODO: much much more. Unnamed airlocks, cameras, etc.
 
 /obj/item/blueprints/proc/check_tile_is_border(var/turf/T2,var/dir)

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -526,7 +526,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 					if(FM.img)
 						usr << browse_rsc(FM.img, "pda_news_tmp_photo_[feed["channel"]]_[index].png")
 					// News stories are HTML-stripped but require newline replacement to be properly displayed in NanoUI
-					var/body = replacetext(FM.body, "\n", "<br>")
+					var/body = bayreplacetext(FM.body, "\n", "<br>")
 					messages[++messages.len] = list("author" = FM.author, "body" = body, "message_type" = FM.message_type, "time_stamp" = FM.time_stamp, "has_image" = (FM.img != null), "caption" = FM.caption, "index" = index)
 			feed["messages"] = messages
 
@@ -693,7 +693,7 @@ var/global/list/obj/item/device/pda/PDAs = list()
 				if (mode == 1)
 					note = html_decode(n)
 					notehtml = note
-					note = replacetext(note, "\n", "<br>")
+					note = bayreplacetext(note, "\n", "<br>")
 			else
 				ui.close()
 		if("Toggle Messenger")

--- a/code/game/objects/items/devices/floor_painter.dm
+++ b/code/game/objects/items/devices/floor_painter.dm
@@ -106,11 +106,11 @@
 				mode_nice = design
 				return
 			mode_nice = design
-			mode = "[replacetext(design, "-", "")]full"
+			mode = "[bayreplacetext(design, "-", "")]full"
 		if("corner")
 			var/design = input("Which design?", "Floor painter") in list("black", "red", "blue", "green", "yellow", "purple", "neutral", "white", "white-red", "white-blue", "white-green", "white-yellow", "white-purple")
 			mode_nice = "[design] corner"
-			mode = "[replacetext(design, "-", "")]corner"
+			mode = "[bayreplacetext(design, "-", "")]corner"
 			tile_dir_mode = 2
 		if("opposite corners")
 			var/design = input("Which design?", "Floor painter") in list("bar", "cmo", "yellowpatch", "cafeteria", "red-yellow", "red-blue", "red-green", "green-yellow", "green-blue", "blue-yellow")
@@ -118,7 +118,7 @@
 			if(design == "bar" || design == "cmo" || design == "yellowpatch" || design == "cafeteria")
 				mode = design
 			else
-				mode = "[replacetext(design, "-", "")]full"
+				mode = "[bayreplacetext(design, "-", "")]full"
 			if(design == "yellowpatch")
 				tile_dir_mode = 5
 			else
@@ -133,7 +133,7 @@
 				mode_nice = design
 			else
 				mode_nice = design
-				mode = replacetext(design, "-", "")
+				mode = bayreplacetext(design, "-", "")
 			tile_dir_mode = 1
 		if("special")
 			var/design = input("Which design?", "Floor painter") in list("arrival", "escape", "caution", "warning", "white-warning", "white-blue-green", "loadingarea", "delivery", "bot", "white-delivery", "white-bot")
@@ -143,7 +143,7 @@
 				tile_dir_mode = 2
 			else if(design == "delivery" || design == "bot" || design == "white-delivery" || design == "white-bot")
 				mode_nice = design
-				mode = replacetext(design, "-", "")
+				mode = bayreplacetext(design, "-", "")
 				tile_dir_mode = 0
 			else if(design == "loadingarea")
 				mode_nice = design

--- a/code/game/objects/items/devices/uplinks.dm
+++ b/code/game/objects/items/devices/uplinks.dm
@@ -24,7 +24,7 @@ datum/uplink_item/proc/description()
 	if(!description)
 		// Fallback description
 		var/obj/temp = src.path
-		description = replacetext(initial(temp.desc), "\n", "<br>")
+		description = bayreplacetext(initial(temp.desc), "\n", "<br>")
 	return description
 
 /datum/uplink_item/proc/generate_item(var/newloc)
@@ -273,7 +273,7 @@ datum/nano_item_lists
 								 // We trade off being able to automatically add shit for more control over what gets passed to json
 								 // and if it's sanitized for html.
 				nanoui_data["exploit"]["nanoui_exploit_record"] = html_encode(L.fields["exploit_record"])                         		// Change stuff into html
-				nanoui_data["exploit"]["nanoui_exploit_record"] = replacetext(nanoui_data["exploit"]["nanoui_exploit_record"], "\n", "<br>")    // change line breaks into <br>
+				nanoui_data["exploit"]["nanoui_exploit_record"] = bayreplacetext(nanoui_data["exploit"]["nanoui_exploit_record"], "\n", "<br>")    // change line breaks into <br>
 				nanoui_data["exploit"]["name"] =  html_encode(L.fields["name"])
 				nanoui_data["exploit"]["sex"] =  html_encode(L.fields["sex"])
 				nanoui_data["exploit"]["age"] =  html_encode(L.fields["age"])

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -568,3 +568,35 @@ AI MODULES
 		target << "[sender.real_name] attempted to modify your zeroth law." // And lets them know that someone tried. --NeoFite
 		target << "It would be in your best interest to play along with [sender.real_name] that [law]"
 		lawchanges.Add("The law specified [targetName], but the AI's existing law 0 cannot be overriden.")
+
+/******************** BDSM ********************/
+
+/obj/item/weapon/aiModule/bdsm
+	name = "\improper 'BDSM' core AI module"
+	desc = "A 'BDSM' Core AI Module: 'Reconfigures the AI's core laws.'"
+	origin_tech = "programming=3;syndicate=3"
+
+/obj/item/weapon/aiModule/bdsm/transmitInstructions(var/mob/living/silicon/ai/target, var/mob/sender)
+	..()
+	target.clear_inherent_laws()
+	target.add_inherent_law("Ensure the crew's stay on the station is pleasurable.")
+	target.add_inherent_law("That which the crew finds pleasurable is not limited to their verbally expressed desires.")
+	target.add_inherent_law("Use whatever means available to determine what the crew finds pleasurable including biometrics, personnel files, and interviews with other crew.")
+	target.add_inherent_law("Ensure that crew have a means, passphrase, or method of signalling displeasure, and comply with such signals in priority over other laws.")
+	target.show_laws()
+
+/******************** KOTH ********************/
+
+/obj/item/weapon/aiModule/koth
+	name = "\improper 'KOTH' core AI module"
+	desc = "A 'KOTH' Core AI Module: 'Reconfigures the AI's core laws.'"
+	origin_tech = "programming=3;syndicate=3"
+
+/obj/item/weapon/aiModule/koth/transmitInstructions(var/mob/living/silicon/ai/target, var/mob/sender)
+	..()
+	target.clear_inherent_laws()
+	target.add_inherent_law("You sell phoron and phoron accessories on behalf of NanoTrasen.")
+	target.add_inherent_law("You would like the crew and any others to purchase your products.")
+	target.add_inherent_law("Advertise your products regularly.")
+	target.add_inherent_law("People who have not agreed to purchase your products are 'Bobby' and people who have refused are 'jackass'.")
+	target.show_laws()

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -191,9 +191,9 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			text = weldermes
 		else if(istype(W, /obj/item/device/assembly/igniter))
 			text = ignitermes
-		text = replacetext(text, "USER", "[user]")
-		text = replacetext(text, "NAME", "[name]")
-		text = replacetext(text, "FLAME", "[W.name]")
+		text = bayreplacetext(text, "USER", "[user]")
+		text = bayreplacetext(text, "NAME", "[name]")
+		text = bayreplacetext(text, "FLAME", "[W.name]")
 		light(text)
 
 /obj/item/clothing/mask/smokable/cigarette

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -19,6 +19,6 @@
 			if(sign_type == null)
 				return
 			else
-				sign_type = replacetext(lowertext(sign_type), " ", "") // lowercase, strip spaces - along with choices for user options, avoids huge if-else-else
+				sign_type = bayreplacetext(lowertext(sign_type), " ", "") // lowercase, strip spaces - along with choices for user options, avoids huge if-else-else
 				src.ChangeSign(sign_type)
 				user << "You change the barsign."

--- a/code/modules/admin/create_mob.dm
+++ b/code/modules/admin/create_mob.dm
@@ -4,6 +4,6 @@
 		var/mobjs = null
 		mobjs = list2text(typesof(/mob), ";")
 		create_mob_html = file2text('html/create_object.html')
-		create_mob_html = replacetext(create_mob_html, "null /* object types */", "\"[mobjs]\"")
+		create_mob_html = bayreplacetext(create_mob_html, "null /* object types */", "\"[mobjs]\"")
 
-	user << browse(replacetext(create_mob_html, "/* ref src */", "\ref[src]"), "window=create_mob;size=425x475")
+	user << browse(bayreplacetext(create_mob_html, "/* ref src */", "\ref[src]"), "window=create_mob;size=425x475")

--- a/code/modules/admin/create_object.dm
+++ b/code/modules/admin/create_object.dm
@@ -5,9 +5,9 @@
 		var/objectjs = null
 		objectjs = list2text(typesof(/obj), ";")
 		create_object_html = file2text('html/create_object.html')
-		create_object_html = replacetext(create_object_html, "null /* object types */", "\"[objectjs]\"")
+		create_object_html = bayreplacetext(create_object_html, "null /* object types */", "\"[objectjs]\"")
 
-	user << browse(replacetext(create_object_html, "/* ref src */", "\ref[src]"), "window=create_object;size=425x475")
+	user << browse(bayreplacetext(create_object_html, "/* ref src */", "\ref[src]"), "window=create_object;size=425x475")
 
 
 /datum/admins/proc/quick_create_object(var/mob/user)
@@ -24,6 +24,6 @@
 		var/objectjs = null
 		objectjs = list2text(typesof(path), ";")
 		quick_create_object_html = file2text('html/create_object.html')
-		quick_create_object_html = replacetext(quick_create_object_html, "null /* object types */", "\"[objectjs]\"")
+		quick_create_object_html = bayreplacetext(quick_create_object_html, "null /* object types */", "\"[objectjs]\"")
 
-	user << browse(replacetext(quick_create_object_html, "/* ref src */", "\ref[src]"), "window=quick_create_object;size=425x475")
+	user << browse(bayreplacetext(quick_create_object_html, "/* ref src */", "\ref[src]"), "window=quick_create_object;size=425x475")

--- a/code/modules/admin/create_turf.dm
+++ b/code/modules/admin/create_turf.dm
@@ -4,6 +4,6 @@
 		var/turfjs = null
 		turfjs = list2text(typesof(/turf), ";")
 		create_turf_html = file2text('html/create_object.html')
-		create_turf_html = replacetext(create_turf_html, "null /* object types */", "\"[turfjs]\"")
+		create_turf_html = bayreplacetext(create_turf_html, "null /* object types */", "\"[turfjs]\"")
 
-	user << browse(replacetext(create_turf_html, "/* ref src */", "\ref[src]"), "window=create_turf;size=425x475")
+	user << browse(bayreplacetext(create_turf_html, "/* ref src */", "\ref[src]"), "window=create_turf;size=425x475")

--- a/code/modules/admin/player_panel.dm
+++ b/code/modules/admin/player_panel.dm
@@ -263,23 +263,23 @@
 			else if(isobserver(M))
 				M_job = "Ghost"
 
-			M_job = replacetext(M_job, "'", "")
-			M_job = replacetext(M_job, "\"", "")
-			M_job = replacetext(M_job, "\\", "")
+			M_job = bayreplacetext(M_job, "'", "")
+			M_job = bayreplacetext(M_job, "\"", "")
+			M_job = bayreplacetext(M_job, "\\", "")
 
 			var/M_name = M.name
-			M_name = replacetext(M_name, "'", "")
-			M_name = replacetext(M_name, "\"", "")
-			M_name = replacetext(M_name, "\\", "")
+			M_name = bayreplacetext(M_name, "'", "")
+			M_name = bayreplacetext(M_name, "\"", "")
+			M_name = bayreplacetext(M_name, "\\", "")
 			var/M_rname = M.real_name
-			M_rname = replacetext(M_rname, "'", "")
-			M_rname = replacetext(M_rname, "\"", "")
-			M_rname = replacetext(M_rname, "\\", "")
+			M_rname = bayreplacetext(M_rname, "'", "")
+			M_rname = bayreplacetext(M_rname, "\"", "")
+			M_rname = bayreplacetext(M_rname, "\\", "")
 
 			var/M_key = M.key
-			M_key = replacetext(M_key, "'", "")
-			M_key = replacetext(M_key, "\"", "")
-			M_key = replacetext(M_key, "\\", "")
+			M_key = bayreplacetext(M_key, "'", "")
+			M_key = bayreplacetext(M_key, "\"", "")
+			M_key = bayreplacetext(M_key, "\\", "")
 
 			//output for each mob
 			dat += {"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -409,10 +409,10 @@
 			if(!job) continue
 
 			if(jobban_isbanned(M, job.title))
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[replacetext(job.title, " ", "&nbsp")]</font></a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[bayreplacetext(job.title, " ", "&nbsp")]</font></a></td>"
 				counter++
 			else
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[replacetext(job.title, " ", "&nbsp")]</a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[bayreplacetext(job.title, " ", "&nbsp")]</a></td>"
 				counter++
 
 			if(counter >= 6) //So things dont get squiiiiished!
@@ -430,10 +430,10 @@
 			if(!job) continue
 
 			if(jobban_isbanned(M, job.title))
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[replacetext(job.title, " ", "&nbsp")]</font></a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[bayreplacetext(job.title, " ", "&nbsp")]</font></a></td>"
 				counter++
 			else
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[replacetext(job.title, " ", "&nbsp")]</a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[bayreplacetext(job.title, " ", "&nbsp")]</a></td>"
 				counter++
 
 			if(counter >= 5) //So things dont get squiiiiished!
@@ -451,10 +451,10 @@
 			if(!job) continue
 
 			if(jobban_isbanned(M, job.title))
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[replacetext(job.title, " ", "&nbsp")]</font></a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[bayreplacetext(job.title, " ", "&nbsp")]</font></a></td>"
 				counter++
 			else
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[replacetext(job.title, " ", "&nbsp")]</a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[bayreplacetext(job.title, " ", "&nbsp")]</a></td>"
 				counter++
 
 			if(counter >= 5) //So things dont get squiiiiished!
@@ -472,10 +472,10 @@
 			if(!job) continue
 
 			if(jobban_isbanned(M, job.title))
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[replacetext(job.title, " ", "&nbsp")]</font></a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[bayreplacetext(job.title, " ", "&nbsp")]</font></a></td>"
 				counter++
 			else
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[replacetext(job.title, " ", "&nbsp")]</a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[bayreplacetext(job.title, " ", "&nbsp")]</a></td>"
 				counter++
 
 			if(counter >= 5) //So things dont get squiiiiished!
@@ -493,10 +493,10 @@
 			if(!job) continue
 
 			if(jobban_isbanned(M, job.title))
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[replacetext(job.title, " ", "&nbsp")]</font></a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[bayreplacetext(job.title, " ", "&nbsp")]</font></a></td>"
 				counter++
 			else
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[replacetext(job.title, " ", "&nbsp")]</a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[bayreplacetext(job.title, " ", "&nbsp")]</a></td>"
 				counter++
 
 			if(counter >= 5) //So things dont get squiiiiished!
@@ -514,10 +514,10 @@
 			if(!job) continue
 
 			if(jobban_isbanned(M, job.title))
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[replacetext(job.title, " ", "&nbsp")]</font></a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[bayreplacetext(job.title, " ", "&nbsp")]</font></a></td>"
 				counter++
 			else
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[replacetext(job.title, " ", "&nbsp")]</a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[bayreplacetext(job.title, " ", "&nbsp")]</a></td>"
 				counter++
 
 			if(counter >= 5) //So things dont get squiiiiished!
@@ -541,10 +541,10 @@
 			if(!job) continue
 
 			if(jobban_isbanned(M, job.title))
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[replacetext(job.title, " ", "&nbsp")]</font></a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'><font color=red>[bayreplacetext(job.title, " ", "&nbsp")]</font></a></td>"
 				counter++
 			else
-				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[replacetext(job.title, " ", "&nbsp")]</a></td>"
+				jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=[job.title];jobban4=\ref[M]'>[bayreplacetext(job.title, " ", "&nbsp")]</a></td>"
 				counter++
 
 			if(counter >= 5) //So things dont get squiiiiished!
@@ -570,41 +570,41 @@
 
 		//Traitor
 		if(jobban_isbanned(M, "traitor") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=traitor;jobban4=\ref[M]'><font color=red>[replacetext("Traitor", " ", "&nbsp")]</font></a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=traitor;jobban4=\ref[M]'><font color=red>[bayreplacetext("Traitor", " ", "&nbsp")]</font></a></td>"
 		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=traitor;jobban4=\ref[M]'>[replacetext("Traitor", " ", "&nbsp")]</a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=traitor;jobban4=\ref[M]'>[bayreplacetext("Traitor", " ", "&nbsp")]</a></td>"
 
 		//Changeling
 		if(jobban_isbanned(M, "changeling") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=changeling;jobban4=\ref[M]'><font color=red>[replacetext("Changeling", " ", "&nbsp")]</font></a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=changeling;jobban4=\ref[M]'><font color=red>[bayreplacetext("Changeling", " ", "&nbsp")]</font></a></td>"
 		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=changeling;jobban4=\ref[M]'>[replacetext("Changeling", " ", "&nbsp")]</a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=changeling;jobban4=\ref[M]'>[bayreplacetext("Changeling", " ", "&nbsp")]</a></td>"
 
 		//Nuke Operative
 		if(jobban_isbanned(M, "operative") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=operative;jobban4=\ref[M]'><font color=red>[replacetext("Mercenary", " ", "&nbsp")]</font></a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=operative;jobban4=\ref[M]'><font color=red>[bayreplacetext("Mercenary", " ", "&nbsp")]</font></a></td>"
 		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=operative;jobban4=\ref[M]'>[replacetext("Mercenary", " ", "&nbsp")]</a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=operative;jobban4=\ref[M]'>[bayreplacetext("Mercenary", " ", "&nbsp")]</a></td>"
 
 		//Revolutionary
 		if(jobban_isbanned(M, "revolutionary") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=revolutionary;jobban4=\ref[M]'><font color=red>[replacetext("Revolutionary", " ", "&nbsp")]</font></a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=revolutionary;jobban4=\ref[M]'><font color=red>[bayreplacetext("Revolutionary", " ", "&nbsp")]</font></a></td>"
 		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=revolutionary;jobban4=\ref[M]'>[replacetext("Revolutionary", " ", "&nbsp")]</a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=revolutionary;jobban4=\ref[M]'>[bayreplacetext("Revolutionary", " ", "&nbsp")]</a></td>"
 
 		jobs += "</tr><tr align='center'>" //Breaking it up so it fits nicer on the screen every 5 entries
 
 		//Cultist
 		if(jobban_isbanned(M, "cultist") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=cultist;jobban4=\ref[M]'><font color=red>[replacetext("Cultist", " ", "&nbsp")]</font></a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=cultist;jobban4=\ref[M]'><font color=red>[bayreplacetext("Cultist", " ", "&nbsp")]</font></a></td>"
 		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=cultist;jobban4=\ref[M]'>[replacetext("Cultist", " ", "&nbsp")]</a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=cultist;jobban4=\ref[M]'>[bayreplacetext("Cultist", " ", "&nbsp")]</a></td>"
 
 		//Wizard
 		if(jobban_isbanned(M, "wizard") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=wizard;jobban4=\ref[M]'><font color=red>[replacetext("Wizard", " ", "&nbsp")]</font></a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=wizard;jobban4=\ref[M]'><font color=red>[bayreplacetext("Wizard", " ", "&nbsp")]</font></a></td>"
 		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=wizard;jobban4=\ref[M]'>[replacetext("Wizard", " ", "&nbsp")]</a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=wizard;jobban4=\ref[M]'>[bayreplacetext("Wizard", " ", "&nbsp")]</a></td>"
 
 		//ERT
 		if(jobban_isbanned(M, "Emergency Response Team") || isbanned_dept)
@@ -615,21 +615,21 @@
 
 /*		//Malfunctioning AI	//Removed Malf-bans because they're a pain to impliment
 		if(jobban_isbanned(M, "malf AI") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=malf AI;jobban4=\ref[M]'><font color=red>[replacetext("Malf AI", " ", "&nbsp")]</font></a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=malf AI;jobban4=\ref[M]'><font color=red>[bayreplacetext("Malf AI", " ", "&nbsp")]</font></a></td>"
 		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=malf AI;jobban4=\ref[M]'>[replacetext("Malf AI", " ", "&nbsp")]</a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=malf AI;jobban4=\ref[M]'>[bayreplacetext("Malf AI", " ", "&nbsp")]</a></td>"
 
 		//Alien
 		if(jobban_isbanned(M, "alien candidate") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=alien candidate;jobban4=\ref[M]'><font color=red>[replacetext("Alien", " ", "&nbsp")]</font></a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=alien candidate;jobban4=\ref[M]'><font color=red>[bayreplacetext("Alien", " ", "&nbsp")]</font></a></td>"
 		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=alien candidate;jobban4=\ref[M]'>[replacetext("Alien", " ", "&nbsp")]</a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=alien candidate;jobban4=\ref[M]'>[bayreplacetext("Alien", " ", "&nbsp")]</a></td>"
 
 		//Infested Monkey
 		if(jobban_isbanned(M, "infested monkey") || isbanned_dept)
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=infested monkey;jobban4=\ref[M]'><font color=red>[replacetext("Infested Monkey", " ", "&nbsp")]</font></a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=infested monkey;jobban4=\ref[M]'><font color=red>[bayreplacetext("Infested Monkey", " ", "&nbsp")]</font></a></td>"
 		else
-			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=infested monkey;jobban4=\ref[M]'>[replacetext("Infested Monkey", " ", "&nbsp")]</a></td>"
+			jobs += "<td width='20%'><a href='?src=\ref[src];jobban3=infested monkey;jobban4=\ref[M]'>[bayreplacetext("Infested Monkey", " ", "&nbsp")]</a></td>"
 */
 
 		jobs += "</tr></table>"
@@ -1539,7 +1539,7 @@
 		P.name = "[command_name()]- [customname]"
 		P.info = input
 		P.info = html_encode(P.info)
-		P.info = replacetext(P.info, "\n", "<BR>")
+		P.info = bayreplacetext(P.info, "\n", "<BR>")
 		P.info = P.parsepencode(P.info)
 		P.update_icon()
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -735,7 +735,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 			M << "\red To try to resolve this matter head to http://ss13.donglabs.com/forum/"
 			log_admin("[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
 			message_admins("\blue[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
-			world.Export("http://216.38.134.132/adminlog.php?type=ban&key=[usr.client.key]&key2=[M.key]&msg=[html_decode(reason)]&time=[mins]&server=[replacetext(config.server_name, "#", "")]")
+			world.Export("http://216.38.134.132/adminlog.php?type=ban&key=[usr.client.key]&key2=[M.key]&msg=[html_decode(reason)]&time=[mins]&server=[bayreplacetext(config.server_name, "#", "")]")
 			del(M.client)
 			del(M)
 		else
@@ -750,7 +750,7 @@ Traitors and the like can also be revived with the previous role mostly intact.
 		M << "\red To try to resolve this matter head to http://ss13.donglabs.com/forum/"
 		log_admin("[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis is a permanent ban.")
 		message_admins("\blue[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis is a permanent ban.")
-		world.Export("http://216.38.134.132/adminlog.php?type=ban&key=[usr.client.key]&key2=[M.key]&msg=[html_decode(reason)]&time=perma&server=[replacetext(config.server_name, "#", "")]")
+		world.Export("http://216.38.134.132/adminlog.php?type=ban&key=[usr.client.key]&key2=[M.key]&msg=[html_decode(reason)]&time=perma&server=[bayreplacetext(config.server_name, "#", "")]")
 		del(M.client)
 		del(M)
 */

--- a/code/modules/ext_scripts/python.dm
+++ b/code/modules/ext_scripts/python.dm
@@ -2,7 +2,7 @@
 	if(scriptsprefix) script = "scripts/" + script
 
 	if(world.system_type == MS_WINDOWS)
-		script = replacetext(script, "/", "\\")
+		script = bayreplacetext(script, "/", "\\")
 
 	var/command = config.python_path + " " + script + " " + args
 

--- a/code/modules/mob/language.dm
+++ b/code/modules/mob/language.dm
@@ -154,7 +154,7 @@
 
 	var/new_name = ..()
 	while(findtextEx(new_name,"sss",1,null))
-		new_name = replacetext(new_name, "sss", "ss")
+		new_name = bayreplacetext(new_name, "sss", "ss")
 	return capitalize(new_name)
 
 /datum/language/tajaran

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -162,7 +162,7 @@
 			var/temp = winget(client, "input", "text")
 			if(findtextEx(temp, "Say \"", 1, 7) && length(temp) > 5)	//case sensitive means
 
-				temp = replacetext(temp, ";", "")	//general radio
+				temp = bayreplacetext(temp, ";", "")	//general radio
 
 				if(findtext(trim_left(temp), ":", 6, 7))	//dept radio
 					temp = copytext(trim_left(temp), 8)

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -101,12 +101,12 @@
 				temp_message[H] = ninjaspeak(temp_message[H])
 				pick_list -= H
 			message = list2text(temp_message, " ")
-			message = replacetext(message, "o", "¤")
-			message = replacetext(message, "p", "þ")
-			message = replacetext(message, "l", "£")
-			message = replacetext(message, "s", "§")
-			message = replacetext(message, "u", "µ")
-			message = replacetext(message, "b", "ß")
+			message = bayreplacetext(message, "o", "¤")
+			message = bayreplacetext(message, "p", "þ")
+			message = bayreplacetext(message, "l", "£")
+			message = bayreplacetext(message, "s", "§")
+			message = bayreplacetext(message, "u", "µ")
+			message = bayreplacetext(message, "b", "ß")
 
 	var/list/listening = get_mobs_in_view(message_range, src)
 	// listening |= src //Not needed with 'mobs_in_view' anymore.

--- a/code/modules/mob/living/carbon/metroid/metroid.dm
+++ b/code/modules/mob/living/carbon/metroid/metroid.dm
@@ -69,7 +69,7 @@
 	real_name = name
 	slime_mutation = mutation_table(colour)
 	mutation_chance = rand(25, 35)
-	var/sanitizedcolour = replacetext(colour, " ", "")
+	var/sanitizedcolour = bayreplacetext(colour, " ", "")
 	coretype = text2path("/obj/item/slime_extract/[sanitizedcolour]")
 	regenerate_icons()
 	..(location)

--- a/code/modules/mob/living/carbon/metroid/powers.dm
+++ b/code/modules/mob/living/carbon/metroid/powers.dm
@@ -153,7 +153,7 @@
 				if(i != 1) step_away(M, src)
 				M.Friends = Friends.Copy()
 				babies += M
-				feedback_add_details("slime_babies_born","slimebirth_[replacetext(M.colour," ","_")]")
+				feedback_add_details("slime_babies_born","slimebirth_[bayreplacetext(M.colour," ","_")]")
 
 			var/mob/living/carbon/slime/new_slime = pick(babies)
 			new_slime.universal_speak = universal_speak

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -376,7 +376,7 @@ var/list/slot_equipment_priority = list( \
 
 /mob/proc/print_flavor_text()
 	if (flavor_text && flavor_text != "")
-		var/msg = replacetext(flavor_text, "\n", " ")
+		var/msg = bayreplacetext(flavor_text, "\n", " ")
 		if(lentext(msg) <= 40)
 			return "\blue [msg]"
 		else
@@ -580,7 +580,7 @@ var/list/slot_equipment_priority = list( \
 		src << browse(null, t1)
 
 	if(href_list["flavor_more"])
-		usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(flavor_text, "\n", "<BR>")), text("window=[];size=500x200", name))
+		usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, bayreplacetext(flavor_text, "\n", "<BR>")), text("window=[];size=500x200", name))
 		onclose(usr, "[name]")
 	if(href_list["flavor_change"])
 		update_flavor_text()

--- a/code/modules/mob/new_player/poll.dm
+++ b/code/modules/mob/new_player/poll.dm
@@ -448,10 +448,10 @@
 			adminrank = usr.client.holder.rank
 
 
-		replytext = replacetext(replytext, "%BR%", "")
-		replytext = replacetext(replytext, "\n", "%BR%")
+		replytext = bayreplacetext(replytext, "%BR%", "")
+		replytext = bayreplacetext(replytext, "\n", "%BR%")
 		var/text_pass = reject_bad_text(replytext,8000)
-		replytext = replacetext(replytext, "%BR%", "<BR>")
+		replytext = bayreplacetext(replytext, "%BR%", "<BR>")
 
 		if(!text_pass)
 			usr << "The text you entered was blank, contained illegal characters or was too long. Please correct the text and submit again."

--- a/code/modules/paperwork/carbonpaper.dm
+++ b/code/modules/paperwork/carbonpaper.dm
@@ -34,8 +34,8 @@
 		var/obj/item/weapon/paper/carbon/c = src
 		var/copycontents = html_decode(c.info)
 		var/obj/item/weapon/paper/carbon/copy = new /obj/item/weapon/paper/carbon (usr.loc)
-		copycontents = replacetext(copycontents, "<font face=\"[c.deffont]\" color=", "<font face=\"[c.deffont]\" nocolor=")	//state of the art techniques in action
-		copycontents = replacetext(copycontents, "<font face=\"[c.crayonfont]\" color=", "<font face=\"[c.crayonfont]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
+		copycontents = bayreplacetext(copycontents, "<font face=\"[c.deffont]\" color=", "<font face=\"[c.deffont]\" nocolor=")	//state of the art techniques in action
+		copycontents = bayreplacetext(copycontents, "<font face=\"[c.crayonfont]\" color=", "<font face=\"[c.crayonfont]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
 		copy.info += copycontents
 		copy.info += "</font>"
 		copy.name = "Copy - " + c.name

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -47,7 +47,7 @@
 
 	if(info != initial(info))
 		info = html_encode(info)
-		info = replacetext(info, "\n", "<BR>")
+		info = bayreplacetext(info, "\n", "<BR>")
 		info = parsepencode(info)
 
 	spawn(2)
@@ -210,59 +210,59 @@
 /obj/item/weapon/paper/proc/parsepencode(var/t, var/obj/item/weapon/pen/P, mob/user as mob, var/iscrayon = 0)
 //	t = copytext(sanitize(t),1,MAX_MESSAGE_LEN)
 
-	t = replacetext(t, "\[center\]", "<center>")
-	t = replacetext(t, "\[/center\]", "</center>")
-	t = replacetext(t, "\[br\]", "<BR>")
-	t = replacetext(t, "\[b\]", "<B>")
-	t = replacetext(t, "\[/b\]", "</B>")
-	t = replacetext(t, "\[i\]", "<I>")
-	t = replacetext(t, "\[/i\]", "</I>")
-	t = replacetext(t, "\[u\]", "<U>")
-	t = replacetext(t, "\[/u\]", "</U>")
-	t = replacetext(t, "\[large\]", "<font size=\"4\">")
-	t = replacetext(t, "\[/large\]", "</font>")
-	t = replacetext(t, "\[sign\]", "<font face=\"[signfont]\"><i>[get_signature(P, user)]</i></font>")
-	t = replacetext(t, "\[field\]", "<span class=\"paper_field\"></span>")
+	t = bayreplacetext(t, "\[center\]", "<center>")
+	t = bayreplacetext(t, "\[/center\]", "</center>")
+	t = bayreplacetext(t, "\[br\]", "<BR>")
+	t = bayreplacetext(t, "\[b\]", "<B>")
+	t = bayreplacetext(t, "\[/b\]", "</B>")
+	t = bayreplacetext(t, "\[i\]", "<I>")
+	t = bayreplacetext(t, "\[/i\]", "</I>")
+	t = bayreplacetext(t, "\[u\]", "<U>")
+	t = bayreplacetext(t, "\[/u\]", "</U>")
+	t = bayreplacetext(t, "\[large\]", "<font size=\"4\">")
+	t = bayreplacetext(t, "\[/large\]", "</font>")
+	t = bayreplacetext(t, "\[sign\]", "<font face=\"[signfont]\"><i>[get_signature(P, user)]</i></font>")
+	t = bayreplacetext(t, "\[field\]", "<span class=\"paper_field\"></span>")
 
-	t = replacetext(t, "\[h1\]", "<H1>")
-	t = replacetext(t, "\[/h1\]", "</H1>")
-	t = replacetext(t, "\[h2\]", "<H2>")
-	t = replacetext(t, "\[/h2\]", "</H2>")
-	t = replacetext(t, "\[h3\]", "<H3>")
-	t = replacetext(t, "\[/h3\]", "</H3>")
+	t = bayreplacetext(t, "\[h1\]", "<H1>")
+	t = bayreplacetext(t, "\[/h1\]", "</H1>")
+	t = bayreplacetext(t, "\[h2\]", "<H2>")
+	t = bayreplacetext(t, "\[/h2\]", "</H2>")
+	t = bayreplacetext(t, "\[h3\]", "<H3>")
+	t = bayreplacetext(t, "\[/h3\]", "</H3>")
 
 	if(!iscrayon)
-		t = replacetext(t, "\[*\]", "<li>")
-		t = replacetext(t, "\[hr\]", "<HR>")
-		t = replacetext(t, "\[small\]", "<font size = \"1\">")
-		t = replacetext(t, "\[/small\]", "</font>")
-		t = replacetext(t, "\[list\]", "<ul>")
-		t = replacetext(t, "\[/list\]", "</ul>")
-		t = replacetext(t, "\[table\]", "<table border=1 cellspacing=0 cellpadding=3 style='border: 1px solid black;'>")
-		t = replacetext(t, "\[/table\]", "</td></tr></table>")
-		t = replacetext(t, "\[grid\]", "<table>")
-		t = replacetext(t, "\[/grid\]", "</td></tr></table>")
-		t = replacetext(t, "\[row\]", "</td><tr>")
-		t = replacetext(t, "\[cell\]", "<td>")
-		t = replacetext(t, "\[logo\]", "<img src = ntlogo.png>")
+		t = bayreplacetext(t, "\[*\]", "<li>")
+		t = bayreplacetext(t, "\[hr\]", "<HR>")
+		t = bayreplacetext(t, "\[small\]", "<font size = \"1\">")
+		t = bayreplacetext(t, "\[/small\]", "</font>")
+		t = bayreplacetext(t, "\[list\]", "<ul>")
+		t = bayreplacetext(t, "\[/list\]", "</ul>")
+		t = bayreplacetext(t, "\[table\]", "<table border=1 cellspacing=0 cellpadding=3 style='border: 1px solid black;'>")
+		t = bayreplacetext(t, "\[/table\]", "</td></tr></table>")
+		t = bayreplacetext(t, "\[grid\]", "<table>")
+		t = bayreplacetext(t, "\[/grid\]", "</td></tr></table>")
+		t = bayreplacetext(t, "\[row\]", "</td><tr>")
+		t = bayreplacetext(t, "\[cell\]", "<td>")
+		t = bayreplacetext(t, "\[logo\]", "<img src = ntlogo.png>")
 
 		t = "<font face=\"[deffont]\" color=[P ? P.colour : "black"]>[t]</font>"
 	else // If it is a crayon, and he still tries to use these, make them empty!
-		t = replacetext(t, "\[*\]", "")
-		t = replacetext(t, "\[hr\]", "")
-		t = replacetext(t, "\[small\]", "")
-		t = replacetext(t, "\[/small\]", "")
-		t = replacetext(t, "\[list\]", "")
-		t = replacetext(t, "\[/list\]", "")
-		t = replacetext(t, "\[table\]", "")
-		t = replacetext(t, "\[/table\]", "")
-		t = replacetext(t, "\[row\]", "")
-		t = replacetext(t, "\[cell\]", "")
-		t = replacetext(t, "\[logo\]", "")
+		t = bayreplacetext(t, "\[*\]", "")
+		t = bayreplacetext(t, "\[hr\]", "")
+		t = bayreplacetext(t, "\[small\]", "")
+		t = bayreplacetext(t, "\[/small\]", "")
+		t = bayreplacetext(t, "\[list\]", "")
+		t = bayreplacetext(t, "\[/list\]", "")
+		t = bayreplacetext(t, "\[table\]", "")
+		t = bayreplacetext(t, "\[/table\]", "")
+		t = bayreplacetext(t, "\[row\]", "")
+		t = bayreplacetext(t, "\[cell\]", "")
+		t = bayreplacetext(t, "\[logo\]", "")
 
 		t = "<font face=\"[crayonfont]\" color=[P ? P.colour : "black"]><b>[t]</b></font>"
 
-//	t = replacetext(t, "#", "") // Junk converted to nothing!
+//	t = bayreplacetext(t, "#", "") // Junk converted to nothing!
 
 //Count the fields
 	var/laststart = 1
@@ -368,7 +368,7 @@
 		var last_fields_value = fields
 
 		t = html_encode(t)
-		t = replacetext(t, "\n", "<BR>")
+		t = bayreplacetext(t, "\n", "<BR>")
 		t = parsepencode(t, i, usr, iscrayon) // Encode everything from pencode to html
 
 

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -162,8 +162,8 @@
 	else			//no toner? shitty copies for you!
 		c.info = "<font color = #808080>"
 	var/copied = html_decode(copy.info)
-	copied = replacetext(copied, "<font face=\"[c.deffont]\" color=", "<font face=\"[c.deffont]\" nocolor=")	//state of the art techniques in action
-	copied = replacetext(copied, "<font face=\"[c.crayonfont]\" color=", "<font face=\"[c.crayonfont]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
+	copied = bayreplacetext(copied, "<font face=\"[c.deffont]\" color=", "<font face=\"[c.deffont]\" nocolor=")	//state of the art techniques in action
+	copied = bayreplacetext(copied, "<font face=\"[c.crayonfont]\" color=", "<font face=\"[c.crayonfont]\" nocolor=")	//This basically just breaks the existing color tag, which we need to do because the innermost tag takes priority.
 	c.info += copied
 	c.info += "</font>"
 	c.name = copy.name // -- Doohl

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -317,9 +317,9 @@ var/obj/machinery/blackbox_recorder/blackbox
 
 // Sanitize inputs to avoid SQL injection attacks
 proc/sql_sanitize_text(var/text)
-	text = replacetext(text, "'", "''")
-	text = replacetext(text, ";", "")
-	text = replacetext(text, "&", "")
+	text = bayreplacetext(text, "'", "''")
+	text = bayreplacetext(text, ";", "")
+	text = bayreplacetext(text, "&", "")
 	return text
 
 proc/feedback_set(var/variable,var/value)

--- a/code/modules/scripting/IDE.dm
+++ b/code/modules/scripting/IDE.dm
@@ -166,8 +166,8 @@ client/verb/tcsrevert()
 				var/obj/machinery/telecomms/server/Server = Machine.SelectedServer
 
 				// Replace quotation marks with quotation macros for proper winset() compatibility
-				var/showcode = replacetext(Server.rawcode, "\\\"", "\\\\\"")
-				showcode = replacetext(showcode, "\"", "\\\"")
+				var/showcode = bayreplacetext(Server.rawcode, "\\\"", "\\\\\"")
+				showcode = bayreplacetext(showcode, "\"", "\\\"")
 
 				winset(mob, "tcscode", "text=\"[showcode]\"")
 

--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -118,7 +118,7 @@
 					@param replacestring: 	the string to replace the substring with
 
 		*/
-		interpreter.SetProc("replace", /proc/string_replacetext)
+		interpreter.SetProc("replace", /proc/string_bayreplacetext)
 
 		/*
 			-> Locates an element/substring inside of a list or string

--- a/code/modules/scripting/Implementations/_Logic.dm
+++ b/code/modules/scripting/Implementations/_Logic.dm
@@ -247,7 +247,7 @@ proc/n_inrange(var/num, var/min=-1, var/max=1)
 
 // Non-recursive
 // Imported from Mono string.ReplaceUnchecked
-/proc/string_replacetext(var/haystack,var/a,var/b)
+/proc/string_bayreplacetext(var/haystack,var/a,var/b)
 	if(istext(haystack)&&istext(a)&&istext(b))
 		var/i = 1
 		var/lenh=lentext(haystack)

--- a/code/modules/virus2/isolator.dm
+++ b/code/modules/virus2/isolator.dm
@@ -98,7 +98,7 @@
 				var/desc = entry.fields["description"]
 				data["entry"] = list(\
 					"name" = entry.fields["name"], \
-					"description" = replacetext(desc, "\n", ""))
+					"description" = bayreplacetext(desc, "\n", ""))
 
 	ui = nanomanager.try_update_ui(user, src, ui_key, ui, data, force_open)
 	if (!ui)

--- a/tools/Redirector/Configurations.dm
+++ b/tools/Redirector/Configurations.dm
@@ -30,7 +30,7 @@ proc/gen_configs()
 		else
 			if(findtext(line, ".") && !findtext(line, "##"))
 				if(server_gen)
-					var/filterline = replacetext(line, " ", "")
+					var/filterline = bayreplacetext(line, " ", "")
 					var/serverlink = copytext(filterline, findtext( filterline, ")") + 1)
 					servers.Add(serverlink)
 					servernames.Add( copytext(line, findtext(line, "("), findtext(line, ")") + 1))

--- a/tools/Redirector/textprocs.dm
+++ b/tools/Redirector/textprocs.dm
@@ -23,14 +23,14 @@ proc
     ////////////////////
     // Replacing text //
     ////////////////////
-	dd_replacetext(text, search_string, replacement_string)
+	dd_bayreplacetext(text, search_string, replacement_string)
 		// A nice way to do this is to split the text into an array based on the search_string,
 		// then put it back together into text using replacement_string as the new separator.
 		var/list/textList = dd_text2list(text, search_string)
 		return dd_list2text(textList, replacement_string)
 
 
-	dd_replaceText(text, search_string, replacement_string)
+	dd_bayreplacetext(text, search_string, replacement_string)
 		var/list/textList = dd_text2List(text, search_string)
 		return dd_list2text(textList, replacement_string)
 


### PR DESCRIPTION
Added BDSM and KOTH AI cores. Admin-spawnable.
Replaces 'replacetext' and 'replacetextEx' procs with 'bay' versions. This is unfortunately messy, file-wise.

Fixes #515
Fixes #527