### PR TITLE
Fixes #533 and #531

### DIFF
--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -345,7 +345,11 @@
 			R << "<span class='notice'>You feel your stomach slowly churn around [patient], breaking them down into a soft slurry to be used as power for your systems.</span>"
 			patient << "<span class='notice'>You feel [R]'s stomach slowly churn around your form, breaking you down into a soft slurry to be used as power for [R]'s systems.</span>"
 			del(patient)
+			R.sleeper_r = 0 //Reset the sprite!
+			R.sleeper_g = 0 //Since they're just power by now.
 			R.cell.charge = R.cell.charge + 30000 //As much as a hyper battery. You /are/ digesting an entire person, after all!
+			src.occupied = 0 //Allow them to take more people in!
+			R.update_icons()
 	else
 		usr << "<span class='notice'>ERROR: Subject cannot metabolise chemicals.</span>"
 	updateUsrDialog()

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -684,7 +684,7 @@
 					msg = html_encode(msg)
 				flavor_texts[href_list["flavor_change"]] = msg
 				return
-				
+
 			if("preferences")
 				var/msg = input(usr,"Set your preferences here, Such as your favorite fetishes, or things that you really dislike!","Flavor Text",html_decode(flavor_texts[href_list["flavor_change"]])) as message
 				if(msg != null)
@@ -1307,6 +1307,7 @@
 			feet_exposed = 0
 
 	flavor_text = flavor_texts["general"]
+	flavor_text += "\n\n"
 	flavor_text += flavor_texts["preferences"] //Not having this + is what made the other one break.
 	flavor_text += "\n\n"
 	for (var/T in flavor_texts)


### PR DESCRIPTION
Fixes both #533 and #531 by making the flavor text have a space in beteween prefs and general, and also automatically updates the borg sprites and empties their stomach.

Pref pic: http://puu.sh/oaWHT/ac663ddf58.png