### PR TITLE
Dogbot QOL Tweaks

### DIFF
--- a/code/game/objects/items/weapons/dogborgstuff.dm
+++ b/code/game/objects/items/weapons/dogborgstuff.dm
@@ -191,7 +191,8 @@
 	var/inject_amount = 10
 	var/min_health = -100
 	var/occupied = 0
-	var/list/injection_chems = list("dexalin", "bicaridine", "kelotane","anti_toxin", "alkysine", "imidazoline", "spaceacillin", "paracetamol", "digestive_enzymes") //The borg is able to heal every damage type. As a nerf, they use 750 charge per injection.
+	var/list/injection_chems = list("dexalin", "bicaridine", "kelotane","anti_toxin", "alkysine", "imidazoline", "spaceacillin", "paracetamol") //The borg is able to heal every damage type. As a nerf, they use 750 charge per injection.
+	var/list/vore_chems = list("digestive_enzymes")
 
 /obj/item/weapon/dogborg/sleeper/Exit(atom/movable/O)
 	return 0
@@ -260,7 +261,8 @@
 /obj/item/weapon/dogborg/sleeper/proc/sleeperUI(mob/user)
 	var/dat
 	dat += "<h3>Injector</h3>"
-	if(patient)
+
+	if(patient && !(patient.stat & DEAD)) //Why inject dead people with innaprov? Dundonuffin in Bay.
 		dat += "<A href='?src=\ref[src];inject=inaprovaline'>Inject Inaprovaline</A>"
 	else
 		dat += "<span class='linkOff'>Inject Inaprovaline</span>"
@@ -271,6 +273,17 @@
 				dat += "<BR><A href='?src=\ref[src];inject=[C.id]'>Inject [C.name]</A>"
 	else
 		for(var/re in injection_chems)
+			var/datum/reagent/C = chemical_reagents_list[re]
+			if(C)
+				dat += "<BR><span class='linkOff'>Inject [C.name]</span>"
+
+	if(patient && patient.digestable) //Respect digestion toggle.
+		for(var/re in vore_chems)
+			var/datum/reagent/C = chemical_reagents_list[re]
+			if(C)
+				dat += "<BR><A href='?src=\ref[src];inject=[C.id]'>Inject [C.name]</A>"
+	else
+		for(var/re in vore_chems)
 			var/datum/reagent/C = chemical_reagents_list[re]
 			if(C)
 				dat += "<BR><span class='linkOff'>Inject [C.name]</span>"
@@ -320,24 +333,27 @@
 	popup.set_title_image(user.browse_rsc_icon(icon, icon_state))
 	popup.set_content(dat)
 	popup.open()
+	return
 
 /obj/item/weapon/dogborg/sleeper/Topic(href, href_list)
 	if(..() || usr == patient)
 		return
 	usr.set_machine(src)
 	if(href_list["refresh"])
-		updateUsrDialog()
+		src.updateUsrDialog()
+		sleeperUI(usr)
 		return
 	if(href_list["eject"])
 		go_out()
+		sleeperUI(usr)
 		return
-	if(patient && patient.stat != DEAD)
+	if(patient && !(patient.stat & DEAD)) //What is bitwise NOT? ... Thought it was tilde.
 		if(href_list["inject"] == "inaprovaline" || patient.health > min_health)
 			inject_chem(usr, href_list["inject"])
 		else
 			usr << "<span class='notice'>ERROR: Subject is not in stable condition for auto-injection.</span>"
 
-	else if(patient && patient.stat == DEAD) //This is so they can digest someone that is dead
+	else if(patient && (patient.stat & DEAD) && patient.digestable) //This is so they can digest someone that is dead
 		var/confirm = alert(usr, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
 		if(confirm == "Okay")
 			var/mob/living/silicon/robot.R = usr
@@ -352,23 +368,26 @@
 			R.update_icons()
 	else
 		usr << "<span class='notice'>ERROR: Subject cannot metabolise chemicals.</span>"
-	updateUsrDialog()
+
+	src.updateUsrDialog()
+	sleeperUI(usr) //Needs a callback to boop the page to refresh.
+	return
 
 /obj/item/weapon/dogborg/sleeper/proc/inject_chem(mob/user, chem)
 	if(patient && patient.reagents)
-		if(chem in injection_chems + "inaprovaline")
+		if(chem in injection_chems + vore_chems + "inaprovaline")
 			var/mob/living/silicon/robot.R = user
-			if(R.cell.charge < 750) //This is so borgs don't kill theirselves with it.
-				R << "<span class='notice'>You don't have enough power to synthesise fluids.</span>"
+			if(R.cell.charge < 800) //This is so borgs don't kill themselves with it.
+				R << "<span class='notice'>You don't have enough power to synthesize fluids.</span>"
 				return
-			else if(patient.reagents.get_reagent_amount(chem) + 10 >= 20) //Preventing people from accidentally killing theirselves by trying to inject too many chemicals!
+			else if(patient.reagents.get_reagent_amount(chem) + 10 >= 20) //Preventing people from accidentally killing themselves by trying to inject too many chemicals!
 				R << "<span class='notice'>Your stomach is currently too full of fluids to secrete more fluids of this kind.</span>"
 			else if(patient.reagents.get_reagent_amount(chem) + 10 <= 20) //No overdoses for you
 				patient.reagents.add_reagent(chem, inject_amount)
 				R.cell.charge = R.cell.charge - 750 //-750 charge per injection
 			var/units = round(patient.reagents.get_reagent_amount(chem))
-			R << "<span class='notice'>Occupant is currently immersed in [units] unit\s of [chemical_reagents_list[chem]].</span>"
-	if(patient && patient.stat == DEAD) //So is this. If they inject a dead person, this pops up.
+			R << "<span class='notice'>Injecting [units] unit\s of [chemical_reagents_list[chem]] into occupant.</span>" //If they were immersed, the reagents wouldn't leave with them.
+	if(patient && (patient.stat & DEAD) && patient.digestable) //So is this. If they inject a dead person, this pops up.
 		var/confirm = alert(user, "Your patient is currently dead! You can digest them to charge your battery, or leave them alive. Do not digest them unless you have their consent, please!", "Confirmation", "Okay", "Cancel")
 		if(confirm == "Okay")
 			var/mob/living/silicon/robot.R = user
@@ -388,14 +407,12 @@
 	patient.AdjustStunned(-4)
 	patient.AdjustWeakened(-4)
 	src.drain()
-	if(patient.reagents.get_reagent_amount("inaprovaline") < 5)
+	if((patient.reagents.get_reagent_amount("inaprovaline") < 5) && (patient.health < patient.maxHealth) && (patient.reagents.get_reagent_amount("digestive_enzymes") == 0)) //Stop pumping full HP people full of drugs. Don't heal people you're digesting, meanie.
 		patient.reagents.add_reagent("inaprovaline", 5)
+
 /mob/living/silicon/robot
 	var/sleeper_g
 	var/sleeper_r
-
-
-
 
 /obj/item/weapon/dogborg/sleeper/K9 //The K9 portabrig
 	name = "Brig-Belly"
@@ -405,4 +422,5 @@
 	inject_amount = 10
 	min_health = -100
 	occupied = 0
-	injection_chems = list("digestive_enzymes") //So they don't have all the same chems as the medihound!
+	injection_chems = null //So they don't have all the same chems as the medihound!
+	vore_chems = list("digestive_enzymes")


### PR DESCRIPTION
Makes dogborgs respect digestable pref. Greys out digestive enzymes when prey are indigestible, and prevents you from digesting indigestible bodies.

Added 'Refuel' button to 'finish' digesting, rather than needing to click an unrelated button to get it to proc the dialog. Only lights up with dead prey who have digestion on.

Fixed Scan button and makes the page refresh when injecting as well.

Can't inject with < 800 energy rather than 750. Still costs 750, but "750 < 750 = false". Could still inject chems and one-click kill yourself. So here's a 50 energy safety net. Keep in mind it's 5 energy per tick on these.

No longer does patient.stat == dead or patient.stat != dead. Don't do direct comparisons on bitfields, and instead, use bitwise operators.

Can't inject innaprov into dead patients (just looked silly). Doesn't auto-inject either, if they are at full health. Feels odd to constantly pump people full of innaprov in endo scenes.

Probably should still be worked into the vore system though.

**Undigestable person in sleeper**
![Imgur](http://i.imgur.com/i3RkVp5.png)

**Dead undigestable person in sleeper**
![Imgur](http://i.imgur.com/PNaorN1.png)

**Digestable person in sleeper**
![Imgur](http://i.imgur.com/UNsJHEM.png)

**Dead digestable person in sleeper ("Refuel" button)**
![Imgur](http://i.imgur.com/WpnfBJ6.png)