### PR TITLE
Job Whitelist

### DIFF
--- a/VOREStation.dme
+++ b/VOREStation.dme
@@ -299,6 +299,7 @@
 #include "code\game\jobs\job\science.dm"
 #include "code\game\jobs\job\security.dm"
 #include "code\game\jobs\job\silicon.dm"
+#include "code\game\jobs\job\special.dm"
 #include "code\game\machinery\adv_med.dm"
 #include "code\game\machinery\ai_slipper.dm"
 #include "code\game\machinery\alarm.dm"

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -59,7 +59,8 @@
 	var/hostedby = null
 	var/respawn = 1
 	var/guest_jobban = 1
-	var/usewhitelist = 0
+	var/usewhitelist = 0				//Old-style job whitelist (covers specific jobs)
+	var/usejobwhitelist = 0				//This is the 'new' job whitelist
 	var/mods_are_mentors = 0
 	var/kick_inactive = 0				//force disconnect for inactive players
 	var/load_jobs_from_txt = 0
@@ -408,6 +409,9 @@
 
 				if ("usewhitelist")
 					config.usewhitelist = 1
+
+				if ("usejobwhitelist")
+					config.usejobwhitelist = 1
 
 				if ("feature_object_spell_system")
 					config.feature_object_spell_system = 1

--- a/code/game/jobs/job/job.dm
+++ b/code/game/jobs/job/job.dm
@@ -41,6 +41,9 @@
 	//If you have use_age_restriction_for_jobs config option enabled and the database set up, this option will add a requirement for players to be at least minimal_player_age days old. (meaning they first signed in at least that many days before.)
 	var/minimal_player_age = 0
 
+	//For job whitelist checking, if enabled. Set to 1 to enable for any particular job.
+	var/job_whitelisted
+
 /datum/job/proc/equip(var/mob/living/carbon/human/H)
 	return 1
 

--- a/code/game/jobs/job/special.dm
+++ b/code/game/jobs/job/special.dm
@@ -1,0 +1,39 @@
+/datum/job/centcom_observer
+	title = "CentCom Observer"
+	flag = CCOBSERVER
+	department_flag = UNIQUE
+	faction = "Station"
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "NanoTrasen Central Command"
+	selection_color = "#c6f1ff"
+	idtype = /obj/item/weapon/card/id/centcom
+	//access = get_all_accesses() + get_centcom_access("Human Affairs Representative")
+	//minimal_access = get_all_accesses() + get_centcom_access("Human Affairs Representative")
+	alt_titles = list("NT Impartial Observer")
+	job_whitelisted = 1
+
+	New()
+		..()
+		access = get_all_accesses() + get_centcom_access("Human Affairs Representative")
+		minimal_access = get_all_accesses() + get_centcom_access("Human Affairs Representative")
+
+	equip(var/mob/living/carbon/human/H)
+		if(!H)	return 0
+		H.equip_to_slot_or_del(new /obj/item/device/radio/headset/ert(H), slot_l_ear)
+		H.equip_to_slot_or_del(new /obj/item/clothing/under/rank/centcom_officer(H), slot_w_uniform)
+		H.equip_to_slot_or_del(new /obj/item/clothing/shoes/laceup(H), slot_shoes)
+		H.equip_to_slot_or_del(new /obj/item/clothing/gloves/white(H), slot_gloves)
+		H.equip_to_slot_or_del(new /obj/item/device/pda/clear(H), slot_belt)
+		H.equip_to_slot_or_del(new /obj/item/weapon/pen/blue(H), slot_r_store)
+		H.equip_to_slot_or_del(new /obj/item/weapon/pen/red(H), slot_l_store)
+		H.equip_to_slot_or_del(new /obj/item/weapon/clipboard(H), slot_l_hand)
+		H.equip_to_slot_or_del(new /obj/item/weapon/paper(H), slot_r_hand)
+		switch(H.backbag)
+			if(1) H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H), slot_r_hand)
+			if(2) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack(H), slot_back)
+			if(3) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
+			if(4) H.equip_to_slot_or_del(new /obj/item/weapon/storage/backpack/satchel(H), slot_back)
+		H.equip_to_slot_or_del(new /obj/item/weapon/storage/box/survival(H.back), slot_in_backpack)
+		return 1
+

--- a/code/game/jobs/job_controller.dm
+++ b/code/game/jobs/job_controller.dm
@@ -82,6 +82,9 @@ var/global/datum/controller/occupations/job_master
 			if(!job.player_old_enough(player.client))
 				Debug("FOC player not old enough, Player: [player]")
 				continue
+			if(job.job_whitelisted && !is_job_whitelisted(player, job.title))
+				Debug("FOC player not whitelisted, Player: [player], Title: [job.title]")
+				continue
 			if(flag && (!player.client.prefs.be_special & flag))
 				Debug("FOC flag failed, Player: [player], Flag: [flag], ")
 				continue
@@ -108,6 +111,10 @@ var/global/datum/controller/occupations/job_master
 
 			if(!job.player_old_enough(player.client))
 				Debug("GRJ player not old enough, Player: [player]")
+				continue
+
+			if(job.job_whitelisted && !is_job_whitelisted(player, job.title))
+				Debug("GRJ player not whitelisted, Player: [player], Title: [job.title]")
 				continue
 
 			if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
@@ -292,6 +299,10 @@ var/global/datum/controller/occupations/job_master
 
 					if(!job.player_old_enough(player.client))
 						Debug("DO player not old enough, Player: [player], Job:[job.title]")
+						continue
+
+					if(job.job_whitelisted && !is_job_whitelisted(player, job.title))
+						Debug("DO player not whitelisted, Player: [player], Title: [job.title]")
 						continue
 
 					// If the player wants that job on this level, then try give it to him.

--- a/code/game/jobs/jobs.dm
+++ b/code/game/jobs/jobs.dm
@@ -45,6 +45,9 @@ var/const/CLOWN				=(1<<11)
 var/const/MIME				=(1<<12)
 var/const/ASSISTANT			=(1<<13)
 
+var/const/UNIQUE			=(1<<3)
+
+var/const/CCOBSERVER		=(1<<0)
 
 var/list/assistant_occupations = list(
 )
@@ -114,6 +117,10 @@ var/list/nonhuman_positions = list(
 	"AI",
 	"Cyborg",
 	"pAI"
+)
+
+var/list/unique_positions = list(
+	"CentCom Observer"
 )
 
 

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -1,5 +1,6 @@
 #define WHITELISTFILE "data/whitelist.txt"
 
+// Original 'job whitelist', old style (for exec jobs).
 var/list/whitelist = list()
 
 /hook/startup/proc/loadWhitelist()
@@ -16,6 +17,43 @@ var/list/whitelist = list()
 		return 0
 	return ("[M.ckey]" in whitelist)
 
+// New 'job whitelist' for flagged jobs.
+/var/list/job_whitelist = list()
+
+/hook/startup/proc/loadJobWhitelist()
+	if(config.usejobwhitelist)
+		load_jobwhitelist()
+	return 1
+
+/proc/load_jobwhitelist()
+	var/text = file2text("config/jobwhitelist.txt")
+	if (!text)
+		log_misc("Failed to load config/jobwhitelist.txt")
+	else
+		job_whitelist = text2list(text, "\n")
+
+/proc/is_job_whitelisted(mob/M, var/job)
+	if(!config.usejobwhitelist)
+		M << "whitelist.dm - Allowing [M.ckey] to play as [job] because whitelisting not enabled."
+		return 1
+	if(check_rights(R_ADMIN, 0))
+		M << "whitelist.dm - Allowing [M.ckey] to play as [job] because they are an admin."
+		return 1
+	if(!job_whitelist)
+		M << "whitelist.dm - Denying [M.ckey] to play as [job] because whitelist enabled but broken."
+		return 0
+	if(M && job)
+		for (var/s in job_whitelist)
+			if(findtext(s,"[M.ckey] - [job]"))
+				M << "whitelist.dm - Allowing [M.ckey] to play as [job] because whitelisted."
+				return 1
+			if(findtext(s,"[M.ckey] - All"))
+				M << "whitelist.dm - Allowing [M.ckey] to play as [job] because whitelisted for 'All'."
+				return 1
+	M << "whitelist.dm - Denying [M.ckey] to play as [job] because not whitelisted."
+	return 0
+
+// Alien whitelist for flagged species.
 /var/list/alien_whitelist = list()
 
 /hook/startup/proc/loadAlienWhitelist()
@@ -30,12 +68,16 @@ var/list/whitelist = list()
 	else
 		alien_whitelist = text2list(text, "\n")
 
-//todo: admin aliens
 /proc/is_alien_whitelisted(mob/M, var/species)
 	if(!config.usealienwhitelist)
 		return 1
-	if(species != "vox" && species != "Vox" && species != "diona" && species != "Diona" && species != "skeleton" && species != "Skeleton")
+
+	/* This is done in preferences.dm, where it checks the flags on the species, why have this?
+	if(species in whitelisted_species)
+		M << "DEBUG: Species isn't in global list."
 		return 1
+	*/
+
 	if(check_rights(R_ADMIN, 0))
 		return 1
 	if(!alien_whitelist)

--- a/code/game/jobs/whitelist.dm
+++ b/code/game/jobs/whitelist.dm
@@ -34,23 +34,17 @@ var/list/whitelist = list()
 
 /proc/is_job_whitelisted(mob/M, var/job)
 	if(!config.usejobwhitelist)
-		M << "whitelist.dm - Allowing [M.ckey] to play as [job] because whitelisting not enabled."
 		return 1
 	if(check_rights(R_ADMIN, 0))
-		M << "whitelist.dm - Allowing [M.ckey] to play as [job] because they are an admin."
 		return 1
 	if(!job_whitelist)
-		M << "whitelist.dm - Denying [M.ckey] to play as [job] because whitelist enabled but broken."
 		return 0
 	if(M && job)
 		for (var/s in job_whitelist)
 			if(findtext(s,"[M.ckey] - [job]"))
-				M << "whitelist.dm - Allowing [M.ckey] to play as [job] because whitelisted."
 				return 1
 			if(findtext(s,"[M.ckey] - All"))
-				M << "whitelist.dm - Allowing [M.ckey] to play as [job] because whitelisted for 'All'."
 				return 1
-	M << "whitelist.dm - Denying [M.ckey] to play as [job] because not whitelisted."
 	return 0
 
 // Alien whitelist for flagged species.

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -118,6 +118,10 @@ datum/preferences
 	var/job_engsec_med = 0
 	var/job_engsec_low = 0
 
+	var/job_unique_high = 0
+	var/job_unique_med = 0
+	var/job_unique_low = 0
+
 	//Keeps track of preferrence for not getting any wanted jobs
 	var/alternate_option = 0
 
@@ -485,7 +489,7 @@ datum/preferences
 
 	user << browse(dat, "window=preferences;size=560x736")
 
-/datum/preferences/proc/SetChoices(mob/user, limit = 16, list/splitJobs = list("Chief Medical Officer"), width = 550, height = 660)
+/datum/preferences/proc/SetChoices(mob/user, limit = 16, list/splitJobs = list("Chief Medical Officer"), width = 600, height = 660)
 	if(!job_master)
 		return
 
@@ -527,6 +531,9 @@ datum/preferences
 		if(!job.player_old_enough(user.client))
 			var/available_in_days = job.available_in_days(user.client)
 			HTML += "<del>[rank]</del></td><td> \[IN [(available_in_days)] DAYS]</td></tr>"
+			continue
+		if(job.job_whitelisted && !is_job_whitelisted(user, rank))
+			HTML += "<del>[rank]</del></td><td> \[WHITELIST]</td></tr>"
 			continue
 		if((job_civilian_low & ASSISTANT) && (rank != "Assistant"))
 			HTML += "<font color=orange>[rank]</font></td><td></td></tr>"
@@ -856,6 +863,10 @@ datum/preferences
 	job_engsec_med = 0
 	job_engsec_low = 0
 
+	job_unique_high = 0
+	job_unique_med = 0
+	job_unique_low = 0
+
 
 /datum/preferences/proc/GetJobDepartment(var/datum/job/job, var/level)
 	if(!job || !level)	return 0
@@ -884,6 +895,14 @@ datum/preferences
 					return job_engsec_med
 				if(3)
 					return job_engsec_low
+		if(UNIQUE)
+			switch(level)
+				if(1)
+					return job_unique_high
+				if(2)
+					return job_unique_med
+				if(3)
+					return job_unique_low
 	return 0
 
 /datum/preferences/proc/SetJobDepartment(var/datum/job/job, var/level)
@@ -893,14 +912,17 @@ datum/preferences
 			job_civilian_high = 0
 			job_medsci_high = 0
 			job_engsec_high = 0
+			job_unique_high = 0
 			return 1
 		if(2)//Set current highs to med, then reset them
 			job_civilian_med |= job_civilian_high
 			job_medsci_med |= job_medsci_high
 			job_engsec_med |= job_engsec_high
+			job_unique_med |= job_unique_high
 			job_civilian_high = 0
 			job_medsci_high = 0
 			job_engsec_high = 0
+			job_unique_high = 0
 
 	switch(job.department_flag)
 		if(CIVILIAN)
@@ -933,6 +955,16 @@ datum/preferences
 					job_engsec_low &= ~job.flag
 				else
 					job_engsec_low |= job.flag
+		if(UNIQUE)
+			switch(level)
+				if(2)
+					job_unique_high = job.flag
+					job_unique_med &= ~job.flag
+				if(3)
+					job_unique_med |= job.flag
+					job_unique_low &= ~job.flag
+				else
+					job_unique_low |= job.flag
 	return 1
 
 /datum/preferences/proc/process_link(mob/user, list/href_list)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -166,7 +166,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 					return
 				src.client.admin_ghost()
 		else
-			response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost, you won't be able to play this round for another 30 minutes! You can't change your mind so choose wisely!)", "Are you sure you want to ghost?", "Ghost", "Stay in body")
+			response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. You should not ghost if you are quitting, you should go to cryo. You cannot undo this.)", "Are you sure you want to ghost?", "Ghost", "Stay in body")
 		if(response != "Ghost")
 			return
 		resting = 1

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -287,6 +287,7 @@
 		if(!job.is_position_available()) return 0
 		if(jobban_isbanned(src,rank))	return 0
 		if(!job.player_old_enough(src.client))	return 0
+		if(job.job_whitelisted && !is_job_whitelisted(src,rank))	return 0
 		return 1
 
 
@@ -300,7 +301,7 @@
 			usr << "<span class='notice'>There is an administrative lock on entering the game!</span>"
 			return 0
 		if(!IsJobAvailable(rank))
-			src << alert("[rank] is not available. Please try another.")
+			src << alert("[rank] is not available (whitelist, jobban, or no slots). Please try another.")
 			return 0
 
 		spawning = 1

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -180,9 +180,13 @@ GUEST_JOBBAN
 
 ## Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting)
 GUEST_BAN
+
 ## Set to jobban everyone who's key is not listed in data/whitelist.txt from Captain, HoS, HoP, CE, RD, CMO, Warden, Security, Detective, and AI positions.
 ## Uncomment to 1 to jobban, leave commented out to allow these positions for everyone (but see GUEST_JOBBAN above and regular jobbans)
 # USEWHITELIST
+
+## Uncomment to use the new job whitelist system. Any job with 'job_whitelisted=1' will only be available for those in jobwhitelist.txt
+# USEJOBWHITELIST
 
 ## set a server location for world reboot. Don't include the byond://, just give the address and port.
 #SERVER server.net:port

--- a/config/example/jobwhitelist.txt
+++ b/config/example/jobwhitelist.txt
@@ -1,0 +1,4 @@
+# File for whitelisted job access
+# Use the 'title' var from jobs and lowercase ckeys please, 'All' works for all titles.
+# Syntax:
+# ckey - Title


### PR DESCRIPTION
This allows any job to be set to require whitelisting by adding the var
"job_whitelisted = 1" to the settings for the job. It also adds a "Unique"
department, and an example job, "CentCom Observer", in a new special.dm
file for the special whitelist/admin jobs. There's no config file for
WHICH jobs are whitelisted yet.

Admins always ignore the whitelist.

This makes the job priorities screen ugly, sorry. It will look nicer when
that third column has more jobs in it, or someone who knows more
HTML-as-tortured-by-Byond can take a crack at it.

**_THINGS YOU SHOULD KNOW:_**
You must create jobwhitelist.txt in the config folder. After updating,
there will be a copy in config/example.

There is a new config file option, USEJOBWHITELIST, that you need to add
to enable job whitelists. Until then, this does not do anything. Do not
use USEWHITELIST, as that is the old version that only applies to head
roles.

You can whitelist any job by going to the appropriate dm (medical.dm,
captain.dm, etc) and adding "job_whitelisted = 1".

I am 'fairly' sure this is robust. Someone extremely sneaky might figure
out a way around it, but I can't think of a way. The randomizer skips you
properly I believe, and you can't pick whitelist jobs when latejoining.

Comments apparently are not ignored in config files so if you do something
like #arokha - All, it will still give all jobs whitelisted.

Resolves #493