### PR TITLE
Cable coils 482

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -96,6 +96,7 @@
 				//Build list of multipliers for sheets.
 				if(R.is_stack)
 					if(max_sheets && max_sheets > 0)
+						max_sheets = min(max_sheets, R.max_stack) // Limit to the max allowed by stack type.
 						multiplier_string  += "<br>"
 						for(var/i = 5;i<max_sheets;i*=2) //5,10,20,40...
 							multiplier_string  += "<a href='?src=\ref[src];make=[index];multiplier=[i]'>\[x[i]\]</a>"

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -72,6 +72,12 @@
 	path = /obj/item/weapon/wirecutters
 	category = "Tools"
 
+/datum/autolathe/recipe/cable
+	name = "cable coil"
+	path = /obj/item/stack/cable_coil
+	category = "Tools"
+	is_stack = 1
+
 /datum/autolathe/recipe/wrench
 	name = "wrench"
 	path = /obj/item/weapon/wrench

--- a/code/game/machinery/autolathe_datums.dm
+++ b/code/game/machinery/autolathe_datums.dm
@@ -16,7 +16,10 @@
 			recipe.resources = list()
 			for(var/material in I.matter)
 				recipe.resources[material] = I.matter[material]*1.25 // More expensive to produce than they are to recycle.
-			del(I)
+		if(recipe.is_stack && istype(I, /obj/item/stack))
+			var/obj/item/stack/IS = I
+			recipe.max_stack = IS.max_amount
+		del(I)
 
 /datum/autolathe/recipe
 	var/name = "object"
@@ -26,6 +29,7 @@
 	var/category
 	var/power_use = 0
 	var/is_stack
+	var/max_stack
 
 /datum/autolathe/recipe/bucket
 	name = "bucket"


### PR DESCRIPTION
Two changes made:

1. Add a recipe to autolathe to produce cable coils.   This is added as an `is_stack = 1` recipe (which tells the autolathe to correctly calculate materials cost for producing stacks)
2. While fixing I noticed that autolathe doesn't limit to the maximum stack size for a stack type.  This normally would not be noticed since metal/glass are expensive enough you'd not have that much loaded in the lathe anyway.  Wires are cheap enough that it is apparent. 