### PR TITLE
Fixes #638 By handling race condition.

### DIFF
--- a/code/modules/power/sensors/sensor_monitoring.dm
+++ b/code/modules/power/sensors/sensor_monitoring.dm
@@ -84,6 +84,7 @@
 // Parameters: None
 // Description: Verifies if any warnings were registered by connected sensors.
 /obj/machinery/computer/power_monitor/proc/check_warnings()
+	if(!power_monitor) return 0; // If power_monitor is not initialized yet...
 	for(var/obj/machinery/power/sensor/S in power_monitor.grid_sensors)
 		if(S.check_grid_warning())
 			return 1


### PR DESCRIPTION
- power_monitor is initialized after a 50 decasecond delay.
- check_warnings() which is called by process() which is called by a
  controller references power_monitor.
- Therefore a race condition allows referencing before it is initialized.
- Solution: Just check if its null, so controller ticks prior to init
  won't boom.