### PR TITLE
Resolves #606 - Adds timestamp to Command Report name.

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -570,10 +570,10 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	for (var/obj/machinery/computer/communications/C in machines)
 		if(! (C.stat & (BROKEN|NOPOWER) ) )
 			var/obj/item/weapon/paper/P = new /obj/item/weapon/paper( C.loc )
-			P.name = "'[command_name()] Update.'"
+			P.name = "[command_name()] Update ([worldtime2text()])"
 			P.info = input
 			P.update_icon()
-			C.messagetitle.Add("[command_name()] Update")
+			C.messagetitle.Add("[command_name()] Update ([worldtime2text()])")
 			C.messagetext.Add(P.info)
 
 	switch(alert("Should this be announced to the general population?",,"Yes","No"))


### PR DESCRIPTION
Adds it onto the name of both the mesage in communications computer and
the name of the paper report.
Example: Central Command Update (12:05)