### PR TITLE
Fix for #657

### DIFF
--- a/code/game/machinery/bots/bots.dm
+++ b/code/game/machinery/bots/bots.dm
@@ -80,6 +80,15 @@
 		else
 			..()
 
+/obj/machinery/bot/attack_generic(var/mob/user, var/damage, var/attack_message)
+	if(!damage)
+		return 0
+	visible_message("<span class='danger'>[user] [attack_message] the [src]!</span>")
+	user.attack_log += text("\[[time_stamp()]\] <font color='red'>attacked [src.name]</font>")
+	src.health -= damage
+	src.healthcheck()
+	..()
+
 /obj/machinery/bot/bullet_act(var/obj/item/projectile/Proj)
 	if(!(Proj.damage_type == BRUTE || Proj.damage_type == BURN))
 		return

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -53,7 +53,7 @@
 
 		if(istype(A, /obj/machinery/bot))
 			var/obj/machinery/bot/B = A
-			if (B.health > 0)
+			if (B.health > 0 && B.on)
 				stance = HOSTILE_STANCE_ATTACK
 				T = B
 				break

--- a/code/modules/mob/living/simple_animal/hostile/vore/vore.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vore/vore.dm
@@ -99,9 +99,15 @@ Don't use ranged mobs for vore mobs.
 /mob/living/simple_animal/hostile/vore/AttackingTarget()
 	if(isliving(target_mob.loc)) //They're inside a mob, maybe us, ignore!
 		return
-	if(picky && !target_mob.digestable)
+
+	if(!isliving(target_mob)) //Can't eat 'em if they ain't alive. Prevents eating borgs/bots.
 		..()
 		return
+
+	if(picky && !target_mob.digestable) //Don't eat people with nogurgle prefs
+		..()
+		return
+
 	if(target_mob.lying && target_mob.playerscale >= min_size && target_mob.playerscale <= max_size && !(target_mob in prey_exclusions))
 		if(capacity)
 			var/check_size = target_mob.playerscale + fullness


### PR DESCRIPTION
/obj/machinery/bot did not implement any behavior on attack_generic, which
is what hostile mobs call on them. The only reason it compiled is because
/obj itself has attack_generic stub with a return in it.

Added an attack_generic proc on bots, and modified hostile code to only
attack 'on' bots. (Why woud a carp care about a thing that looks like a
bucket when it's not moving?)

Also fixed several runtimes with trying to check the digestability of a
bot.

Fixes #657