### PR TITLE
Fix for #650

### DIFF
--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -275,6 +275,12 @@ proc/blood_incompatible(donor,receiver,donor_species,receiver_species)
 
 proc/blood_splatter(var/target,var/datum/reagent/blood/source,var/large)
 
+	//We're not going to splatter at all because we're in something and that's silly.
+	if(istype(source,/atom/movable))
+		var/atom/movable/A = source
+		if(!isturf(A.loc))
+			return
+
 	var/obj/effect/decal/cleanable/blood/B
 	var/decal_type = /obj/effect/decal/cleanable/blood/splatter
 	var/turf/T = get_turf(target)


### PR DESCRIPTION
Bails out of the blood splatter proc early in blood.dm if the place we're
in is not a turf (also causes lockers to not leak blood which is too bad,
owell.)

Fixes #650