### PR TITLE
Fix for #231

### DIFF
--- a/VOREStation.dme
+++ b/VOREStation.dme
@@ -1587,7 +1587,6 @@
 #include "code\modules\virus2\helpers.dm"
 #include "code\modules\virus2\isolator.dm"
 #include "code\modules\virus2\items_devices.dm"
-#include "code\modules\vore\hotfixes.dm"
 #include "code\modules\vore\resize.dm"
 #include "code\modules\vore\spiderTaurPowers.dm"
 #include "code\modules\vore\vore.dm"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -84,7 +84,7 @@
 
 	//Non-default verbs go here
 
-	verbs += /mob/proc/fixtaur // Temporary fix until we unfuck taurs. -Ace
+	//verbs += /mob/proc/fixtaur //Leaving this so I can remember what it looks like -Aro
 	// Vore Code End
 
 /mob/living/carbon/human/Stat()

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -927,7 +927,8 @@ proc/get_damage_icon_part(damage_state, body_part)
 				//Note, this could be moved to the switch above if needed, but currently every taur uses _MULTIPLY
 				taur_s.Blend(rgb(r_taur, g_taur, b_taur), ICON_MULTIPLY)
 				 //Apply taur to overlays, with required pixel offset applied.
-				overlays_standing[TAIL_LAYER] = image(taur_s, "pixel_x" = (-16*playerscale))
+				//overlays_standing[TAIL_LAYER] = image(taur_s, "pixel_x" = (-16*playerscale))
+				overlays_standing[TAIL_LAYER] = image(taur_s, "pixel_x" = -16)
 
 	else if(src.tail_style)
 		if(!wear_suit || !(wear_suit.flags_inv & HIDETAIL) && !istype(wear_suit, /obj/item/clothing/suit/space))

--- a/code/modules/vore/resize.dm
+++ b/code/modules/vore/resize.dm
@@ -31,9 +31,11 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 
 // Ace was here! Redid this a little so we'd use math for shrinking characters. This is the old code.
 /mob/living/proc/set_size()
-	set name = "Set character size"
-	set category = "Resize"
-	var/playersize = input("Size") in list("Macro", "Big", "Normal", "Small", "Tiny")
+	set name = "Set Character Size"
+	set category = "Vore"
+	var/nagmessage = "DO NOT ABUSE THESE COMMANDS. They are not here for you to play with. We were originally going to remove them but kept them for popular demand. \
+			Do not abuse their existence outside of ERP scenes where they apply, or reverting OOCly unwanted changes like someone lolshooting the crew with a shrink ray. -Ace"
+	var/playersize = input(nagmessage,"Pick a Size") in list("Macro", "Big", "Normal", "Small", "Tiny")
 	switch(playersize)
 		if("Macro")
 			resize(RESIZE_HUGE)
@@ -53,10 +55,11 @@ var/const/RESIZE_A_SMALLTINY = (RESIZE_SMALL + RESIZE_TINY) / 2
 /* When we add this to character customization, "short" will set you a little smaller basesize than normal, or "tall" for one that's a little larger than normal.
 If a player choses "Small" "Tiny" "Big" or "Macro" and not "tall" or "short", they will be set as that size. Not change their basesize which will be 1.
 If we change the basesize with other options it will cause bad results. "Tall" and "Short" will be purely within humanoid size ranges.
--Ace */
+-Ace
 
 /mob/verb/resize_Readme()
-	set name = "READ ME!!"
-	set category = "Resize"
+	set name = "READ"
+	set category = "Vore"
 	usr << "<span class='alert'>DO NOT ABUSE THESE COMMANDS. They are not here for you to play with. We were originally going to remove them but kept them for popular demand. \
 			Do not abuse their existence outside of ERP scenes where they apply, or reverting OOCly unwanted changes like someone lolshooting the crew with a shrink ray. -Ace</span>"
+*/


### PR DESCRIPTION
Removed the math that was causing the sprites to be misaligned on taurs
that were not scale 1.0 when recalculating tail visibility.

Also moved Resize to Vore because that tab was boring and now gone.

Fixes #231