### PR TITLE
Fixes cyborg sprite when reset module is used #629

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -30,6 +30,9 @@
 	R.uneq_all()
 	R.hands.icon_state = "nomod"
 	R.icon_state = "robot"
+	R.icon = 'icons/mob/robots.dmi' //There are two files that has the "/obj/item/borg/upgrade/reset/" path.
+	R.pixel_x = initial(pixel_x) //This is the correct one. Don't make the mistake I made. ~CK
+	R.pixel_y = initial(pixel_y)
 	//world << R.custom_sprite
 	if(R.custom_sprite == 1)
 		//world << R.icon_state


### PR DESCRIPTION
#629 
Exactly what it says on the tin. 

I was also going to fix the "Resetting the borg to normal charge" part attached to the issue, but I didn't see exactly where it could be fixed without causing issues. (Ex: Borg infinitely charging with no stop), and this is the biggest problem in that issue request. Borgs walking into a charger with above max charge really isn't a huge issue.

