### PR TITLE
Fix for #674 + message tweak

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -149,6 +149,14 @@
 
 	H.set_cloned_appearance()
 
+	if(H.client.prefs)
+		H.vore_organs = H.client.prefs.belly_prefs.Copy()
+		for(var/I in H.vore_organs)
+			var/datum/belly/B = H.vore_organs[I]
+			B.owner = H
+			B.internal_contents = list()
+			B.digest_mode = DM_HOLD
+
 	for(var/datum/language/L in R.languages)
 		H.add_language(L.name)
 	H.flavor_texts = R.flavor.Copy()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1917,8 +1917,8 @@ datum/preferences
 
 	character.vore_selected = character.vore_organs[1]
 
-	for(var/O in character.vore_organs)
-		var/datum/belly/B = character.vore_organs[O]
+	for(var/I in character.vore_organs)
+		var/datum/belly/B = character.vore_organs[I]
 		B.owner = character
 
 	character.digestable = digestable

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1495,7 +1495,7 @@
 			src << "<font color='red'><b>"+pick("It hurts so much!", "You really need some painkillers..", "Dear god, the pain!")
 
 		if(shock_stage >= 30)
-			if(shock_stage == 30) emote("me",1,"is having trouble keeping their eyes open.")
+			if(shock_stage == 30) visible_message("\red [src] is having trouble keeping their eyes open.")
 			eye_blurry = max(2, eye_blurry)
 			stuttering = max(stuttering, 5)
 
@@ -1503,7 +1503,7 @@
 			src << "<font color='red'><b>"+pick("The pain is excrutiating!", "Please, just end the pain!", "Your whole body is going numb!")
 
 		if (shock_stage >= 60)
-			if(shock_stage == 60) emote("me",1,"'s body becomes limp.")
+			if(shock_stage == 60) visible_message("\red [src]'s body becomes limp.")
 			if (prob(2))
 				src << "<font color='red'><b>"+pick("The pain is excrutiating!", "Please, just end the pain!", "Your whole body is going numb!")
 				Weaken(20)
@@ -1519,7 +1519,7 @@
 				Paralyse(5)
 
 		if(shock_stage == 150)
-			emote("me",1,"can no longer stand, collapsing!")
+			visible_message("\red [src] collapses!")
 			Weaken(20)
 
 		if(shock_stage >= 150)

--- a/code/modules/vore/vore.dm
+++ b/code/modules/vore/vore.dm
@@ -94,7 +94,7 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 	set name = "Save Vore Prefs"
 	set category = "Vore"
 
-	var/result
+	var/result = 0
 
 	if(client.prefs)
 		result = client.prefs.save_vore_preferences()


### PR DESCRIPTION
Fixes #674, and also fixes the stupid 'collapsing' messages you can see
while someone is inside a belly. Changes them to visible_message which
should prevent people from 'seeing' it when they can't 'see' the person.