### PR TITLE
Fix for scan->cryo->rejoin->scan

### DIFF
--- a/code/game/dna/dna_modifier.dm
+++ b/code/game/dna/dna_modifier.dm
@@ -13,7 +13,7 @@
 
 	// Stuff for cloners
 	var/id=null
-	var/implant=null
+	var/obj/item/weapon/implant/health/implant=null
 	var/ckey=null
 	var/mind=null
 	var/languages=null

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -147,9 +147,10 @@
 			else
 				dat += {"<br><font size=1><a href='byond://?src=\ref[src];del_rec=1'>Delete Record</a></font><br>
 					<b>Name:</b> [src.active_record.dna.real_name]<br>"}
+
 				var/obj/item/weapon/implant/health/H = null
 				if(src.active_record.implant)
-					H=locate(src.active_record.implant)
+					H = src.active_record.implant
 
 				if ((H) && (istype(H)))
 					dat += "<b>Health:</b> [H.sensehealth()] | OXY-BURN-TOX-BRUTE<br>"
@@ -378,10 +379,10 @@
 	if (isnull(imp))
 		imp = new /obj/item/weapon/implant/health(subject)
 		imp.implanted = subject
-		R.implant = "\ref[imp]"
+		R.implant = imp
 	//Update it if needed
 	else
-		R.implant = "\ref[imp]"
+		R.implant = imp
 
 	if (!isnull(subject.mind)) //Save that mind so traitors can continue traitoring after cloning.
 		R.mind = "\ref[subject.mind]"

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -194,23 +194,6 @@
 	var/obj/machinery/computer/cryopod/control_computer
 	var/last_no_computer_message = 0
 
-	// These items are preserved when the process() despawn proc occurs.
-	var/list/preserve_items = list(
-		/obj/item/weapon/hand_tele,
-		/obj/item/weapon/card/id, //this will make all id's do be stored. Orbis
-		/obj/item/weapon/card/id/captains_spare,
-		/obj/item/device/aicard,
-		/obj/item/device/mmi,
-		/obj/item/device/paicard,
-		/obj/item/weapon/gun,
-		/obj/item/weapon/pinpointer,
-		/obj/item/clothing/suit,
-		/obj/item/clothing/shoes/magboots,
-		/obj/item/blueprints,
-		/obj/item/clothing/head/helmet/space,
-		/obj/item/weapon/storage/internal
-	)
-
 /obj/machinery/cryopod/right
 	orient_right = 1
 	icon_state = "body_scanner_0-r"
@@ -329,20 +312,23 @@
 
 	for(var/obj/item/W in items)
 
-		var/preserve = null
-		for(var/T in preserve_items)
-			if(istype(W,T))
-				preserve = 1
-				break
+		if(istype(W,/obj/item/weapon/implant/health))
+			for(var/obj/machinery/computer/cloning/com in world)
+				for(var/datum/dna2/record/R in com.records)
+					if(R.implant == W)
+						del(R)
+						del(W)
+						//break //Might be heplful? What if they have more than one?
 
-		if(!preserve)
-			del(W)
-		else
+		if(W.type in important_items)
 			if(control_computer && control_computer.allow_items)
 				control_computer.frozen_items += W
 				W.loc = null
 			else
 				W.loc = src.loc
+
+		else
+			del(W)
 
 	//Update any existing objectives involving this mob.
 	for(var/datum/objective/O in all_objectives)


### PR DESCRIPTION
Makes cryo search people for health implants, and deletes the associated
record from the scanning database whenever the person is deleted for cryo
purposes. Also made the proc for finding preserved items less expensive.

Surely there was an issue about this at some point? Maybe not anymore?