### PR TITLE
The return of bellytext in examines

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -280,9 +280,9 @@
 
 
 	// For each belly type, print description if someone is inside!
-	for (var/bellytype in src.vore_organs)
-		var/datum/belly/B = vore_organs[bellytype]
-		msg += B.get_examine_msg(t_He, t_his, t_him, t_has, t_is)
+	for (var/I in src.vore_organs)
+		var/datum/belly/B = vore_organs[]
+		msg += B.get_examine_msg()
 
 	msg += "</span>"
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -281,7 +281,7 @@
 
 	// For each belly type, print description if someone is inside!
 	for (var/I in src.vore_organs)
-		var/datum/belly/B = vore_organs[]
+		var/datum/belly/B = vore_organs[I]
 		msg += B.get_examine_msg()
 
 	msg += "</span>"

--- a/code/modules/vore/belly/belly.dm
+++ b/code/modules/vore/belly/belly.dm
@@ -45,7 +45,6 @@ belly_prefs["immutable"] = BOOLEAN
 	var/tmp/recent_struggle = 0					// Flag to prevent struggle emote spam
 	var/tmp/emotePend = 0						// If there's already a spawned thing counting for the next emote
 
-
 	// Don't forget to watch your commas at the end of each line if you change these.
 	var/list/struggle_messages_outside = list(
 		"%pred's %belly wobbles with a squirming meal.",
@@ -90,6 +89,10 @@ belly_prefs["immutable"] = BOOLEAN
 		"%pred's %belly groans as you fall apart into a thick soup. Your remains soon flow deeper into %pred's body to be absorbed.",
 		"%pred's %belly kneads on every fiber of your body, softening you down into mush to fuel their next hunt.",
 		"%pred's %belly churns you down into a hot slush. Your nutrient-rich remains course through their digestive track with a series of long, wet glorps.")
+
+	var/list/examine_messages = list(
+		"They have something solid in their %belly!",
+		"It looks like they have something in their %belly!")
 
 	var/list/vore_sounds = list(
 		"Gulp" = 'sound/vore/gulp.ogg',
@@ -152,19 +155,27 @@ belly_prefs["immutable"] = BOOLEAN
 /datum/belly/proc/release_specific_contents(var/atom/movable/M)
 	if (!(M in internal_contents))
 		return 0 // They weren't in this belly anyway
+
 	M.loc = owner.loc  // Move the belly contents into the same location as belly's owner.
 	src.internal_contents -= M  // Remove from the belly contents
 
 	if(istype(M,/mob/living))
 		var/mob/living/ML = M
-		ML.absorbed = 0
+		if(ML.absorbed)
+			ML.absorbed = 0
+			ML.reagents = new/datum/reagents(1000,M) //Human reagent datums hold 1000
+			var/datum/reagents/OR = owner.reagents
+			var/absorbed_count = 2 //Prey that we were, plus the pred gets a portion
+			for(var/mob/living/P in internal_contents)
+				if(P.absorbed)
+					absorbed_count++
 
-	if (isliving(owner.loc)) // This makes sure that the mob behaves properly if released into another mob
-		var/mob/living/loc_mob = owner.loc
-		for (var/bellytype in loc_mob.vore_organs)
-			var/datum/belly/belly = loc_mob.vore_organs[bellytype]
-			if (owner in belly.internal_contents)
-				belly.internal_contents += M
+			OR.trans_to(ML,OR.total_volume / absorbed_count)
+
+
+	var/datum/belly/B = check_belly(M.loc)
+	if(B)
+		B.internal_contents += M
 
 	owner.visible_message("<font color='green'><b>[owner] expels [M] from their [lowertext(name)]!</b></font>")
 	owner.update_icons()
@@ -189,14 +200,20 @@ belly_prefs["immutable"] = BOOLEAN
 // is examined.   By making this a proc, we not only take advantage of polymorphism,
 // but can easily make the message vary based on how many people are inside, etc.
 // Returns a string which shoul be appended to the Examine output.
-/datum/belly/proc/get_examine_msg(t_He, t_his, t_him, t_has, t_is)
-	return
+/datum/belly/proc/get_examine_msg()
+	if(internal_contents.len && examine_messages.len)
+		var/formatted_message
+		var/raw_message = pick(examine_messages)
+
+		formatted_message = bayreplacetext(raw_message,"%belly",lowertext(name))
+
+		return(formatted_message+"<BR>")
 
 // The next function gets the messages set on the belly, in human-readable format.
 // This is useful in customization boxes and such. The delimiter right now is \n\n so
 // in message boxes, this looks nice and is easily delimited.
 /datum/belly/proc/get_messages(var/type, var/delim = "\n\n")
-	ASSERT(type == "smo" || "smi" || "dmo" || "dmp")
+	ASSERT(type == "smo" || type == "smi" || type == "dmo" || type == "dmp" || type == "em")
 	var/list/raw_messages
 
 	switch(type)
@@ -208,6 +225,8 @@ belly_prefs["immutable"] = BOOLEAN
 			raw_messages = digest_messages_owner
 		if("dmp")
 			raw_messages = digest_messages_prey
+		if("em")
+			raw_messages = examine_messages
 
 	var/messages = list2text(raw_messages,delim)
 	return messages
@@ -216,7 +235,7 @@ belly_prefs["immutable"] = BOOLEAN
 // replacement strings and linebreaks as delimiters (two \n\n by default).
 // They also sanitize the messages.
 /datum/belly/proc/set_messages(var/raw_text, var/type, var/delim = "\n\n")
-	ASSERT(type == "smo" || type == "smi" || type == "dmo" || type == "dmp")
+	ASSERT(type == "smo" || type == "smi" || type == "dmo" || type == "dmp" || type == "em")
 
 	var/list/raw_list = text2list(html_encode(raw_text),delim)
 	if(raw_list.len > 10)
@@ -243,6 +262,8 @@ belly_prefs["immutable"] = BOOLEAN
 			digest_messages_owner = raw_list
 		if("dmp")
 			digest_messages_prey = raw_list
+		if("em")
+			examine_messages = raw_list
 
 	return
 
@@ -270,6 +291,11 @@ belly_prefs["immutable"] = BOOLEAN
 	if (config.items_survive_digestion)
 		for (var/obj/item/W in M)
 			_handle_digested_item(W)
+
+	//Reagent transfer
+	if(M.reagents && istype(M.reagents,/datum/reagents))
+		var/datum/reagents/RL = M.reagents
+		RL.trans_to(owner,RL.total_volume*0.5)
 
 	// Delete the digested mob
 	del(M)
@@ -311,6 +337,14 @@ belly_prefs["immutable"] = BOOLEAN
 	M.absorbed = 1
 	M << "<span class='notice'>[owner]'s [name] absorbs your body, making you part of them.</span>"
 	owner << "<span class='notice'>Your [name] absorbs [M]'s body, making them part of you.</span>"
+
+	//Reagent sharing for absorbed with pred
+	var/datum/reagents/OR = owner.reagents
+	var/datum/reagents/PR = M.reagents
+
+	PR.trans_to(owner,PR.total_volume)
+	M.reagents = OR
+	del(PR)
 
 	//This is probably already the case, but for sub-prey, it won't be.
 	M.loc = owner

--- a/code/modules/vore/vore_panel.dm
+++ b/code/modules/vore/vore_panel.dm
@@ -404,6 +404,7 @@
 			"Digest Message (to you)",
 			"Struggle Message (outside)",
 			"Struggle Message (inside)",
+			"Examine Message (when full)",
 			"Reset All To Default",
 			"Cancel - No Changes"
 		)
@@ -432,6 +433,11 @@
 				var/new_message = input(user,"These are sent to prey when they struggle. Write them in 2nd person ('you feel X'). Avoid using %prey in this type."+help,"Struggle Message (inside)",selected.get_messages("smi")) as message
 				if(new_message)
 					selected.set_messages(new_message,"smi")
+
+			if("Examine Message (when full)")
+				var/new_message = input(user,"These are sent to people who examine you when this belly has contents. Write them in 3rd person ('Their %belly is bulging'). Do not use %pred or %prey in this type."+help,"Examine Message (when full)",selected.get_messages("em")) as message
+				if(new_message)
+					selected.set_messages(new_message,"em")
 
 			if("Reset All To Default")
 				var/confirm = alert(user,"This will delete any custom messages. Are you sure?","Confirmation","DELETE","Cancel")


### PR DESCRIPTION
This wasn't intentionally removed, but sorta half-broken. So now you can edit your belly's examine text messages, and by that I mean the messages it gives to people who examine you when you have someone/something in a belly.

"Their taurguts are swinging a bit low."

etc.